### PR TITLE
Add utilities to generate schemas from hydrate resolvers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  core: vanilla/core@2.1.0
+  core: vanilla/core@2
 aliases:
   - &attach_workspace
     attach_workspace:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 infection.log
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -132,14 +132,17 @@ The `DataHydrator` class doesn't provide much functionality with its built-in re
 Let's take an example where we want to have an `lcase` resolver to lowercase strings. Garden Hydrate provides a nifty `FunctionResolver` helper class to help you map any callable to a resolver using reflection.
 
 ```php
-$hydrator = new \Garden\Hydrate\DataHydrator();
+use Garden\Hydrate\Resolvers\FunctionResolver;
+use \Garden\Hydrate\DataHydrator;
+
+$hydrator = new DataHydrator();
 $lcase = new FunctionResolver(function (string $string) {
   return strtolower($string);
 });
-$hydrator->addResolver('lcase', $lcase);
+$hydrator->addResolver($lcase);
 
 $r = $hydrator->resolve([
-  '@hyrdate' => 'lcase',
+  '@hydrate' => 'lcase',
   'string' => 'STOP YELLING'
 ]);
 // $r will be "stop yelling"

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "ext-json": "*",
         "vanilla/garden-jsont": "^1.2",
         "vanilla/garden-schema": "~1.10.2"
     },

--- a/psalm.xml
+++ b/psalm.xml
@@ -43,6 +43,7 @@
         <MissingParamType errorLevel="info" />
 
         <RedundantCondition errorLevel="info" />
+        <MoreSpecificReturnType errorLevel="info" />
 
         <DocblockTypeContradiction errorLevel="info" />
         <RedundantConditionGivenDocblockType errorLevel="info" />

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -214,10 +214,10 @@ class DataHydrator {
      * Get a resolver from the registered resolvers.
      *
      * @param string $type
-     * @return DataResolverInterface
+     * @return AbstractDataResolver
      * @throws ResolverNotFoundException Throws an exception if the resolver isn't registered.
      */
-    private function getResolver(string $type): DataResolverInterface {
+    private function getResolver(string $type): AbstractDataResolver {
         if (!$this->hasResolver($type)) {
             throw new ResolverNotFoundException("Resolver not registered: $type");
         }

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -357,6 +357,12 @@ class DataHydrator {
         };
     }
 
+    /**
+     * Get the name of a callable.
+     *
+     * @param callable $callable
+     * @return string
+     */
     public static function getCallableName(callable $callable): string {
         if (is_string($callable)) {
             return trim($callable);

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -53,13 +53,17 @@ class DataHydrator {
     /** @var ParamResolver */
     private $paramResolver;
 
+    /** @var LiteralResolver */
+    private $literalResolver;
+
     /**
      * DataHydrator constructor.
      */
     public function __construct() {
         $this->setExceptionHandler(new NullExceptionHandler());
 
-        $this->addResolver(new LiteralResolver());
+        $this->literalResolver = new LiteralResolver();
+        $this->addResolver($this->literalResolver);
         $this->paramResolver = new ParamResolver();
         $this->addResolver($this->paramResolver);
         $this->addResolver(new RefResolver());
@@ -242,7 +246,8 @@ class DataHydrator {
                 }
             }
             // Handle the special case for a literal value.
-            if (isset($data[self::KEY_HYDRATE]) && $data[self::KEY_HYDRATE] === 'literal' && isset($data['data'])) {
+            if (isset($data[self::KEY_HYDRATE]) && $data[self::KEY_HYDRATE] === LiteralResolver::TYPE) {
+                $result['data'] = $this->literalResolver->resolve($data);
                 $result['data'] = $data['data'];
                 unset($recurse['data']);
             }

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -8,17 +8,21 @@
 namespace Garden\Hydrate;
 
 use Exception;
+use Garden\Hydrate\Exception\InvalidHydrateSpecException;
 use Garden\Hydrate\Exception\ResolverNotFoundException;
 use Garden\Hydrate\Middleware\TransformMiddleware;
+use Garden\Hydrate\Resolvers\AbstractDataResolver;
 use Garden\Hydrate\Resolvers\LiteralResolver;
 use Garden\Hydrate\Resolvers\ParamResolver;
 use Garden\Hydrate\Resolvers\RefResolver;
 use Garden\Hydrate\Resolvers\SprintfResolver;
+use Garden\Hydrate\Schema\JsonSchemaGenerator;
+use Garden\Schema\Schema;
 
 /**
  * Allows data to by hydrated based on a spec that can include data resolvers or literal data.
  */
-class DataHydrator implements DataResolverInterface {
+class DataHydrator {
     use MiddlewareCollectionTrait;
 
     public const KEY_HYDRATE = '$hydrate';
@@ -27,7 +31,7 @@ class DataHydrator implements DataResolverInterface {
     public const KEY_ROOT = '$root';
 
     /**
-     * @var DataResolverInterface[]
+     * @var AbstractDataResolver[]
      */
     private $resolvers = [];
 
@@ -41,7 +45,6 @@ class DataHydrator implements DataResolverInterface {
      */
     private $exceptionHandler;
 
-
     /**
      * @var DataResolverInterface A combination of the middleware and inner resolver for resolving nodes.
      */
@@ -53,23 +56,27 @@ class DataHydrator implements DataResolverInterface {
     public function __construct() {
         $this->setExceptionHandler(new NullExceptionHandler());
 
-        $this->addResolver('literal', new LiteralResolver());
-        $this->addResolver('param', new ParamResolver());
-        $this->addResolver('ref', new RefResolver());
-        $this->addResolver('sprintf', new SprintfResolver());
+        $this->addResolver(new LiteralResolver());
+        $this->addResolver(new ParamResolver());
+        $this->addResolver(new RefResolver());
+        $this->addResolver(new SprintfResolver());
 
         $this->addMiddleware(new TransformMiddleware());
+    }
+
+    public function getSchemaGenerator(): JsonSchemaGenerator {
+        $generator = new JsonSchemaGenerator($this->resolvers, $this->middlewares);
+        return $generator;
     }
 
     /**
      * Add a new resolver.
      *
-     * @param string $type
-     * @param DataResolverInterface $resolver
+     * @param AbstractDataResolver $resolver
      * @return $this
      */
-    public function addResolver(string $type, DataResolverInterface $resolver) {
-        $this->resolvers[$type] = $resolver;
+    public function addResolver(AbstractDataResolver $resolver) {
+        $this->resolvers[$resolver->getType()] = $resolver;
         return $this;
     }
 
@@ -143,10 +150,16 @@ class DataHydrator implements DataResolverInterface {
      * @param array $params
      * @return array|mixed
      * @throws ResolverNotFoundException Throws an exception when there isn't a resolver registered.
+     * @throws InvalidHydrateSpecException Throws if the hydrate key field is invalid.
      */
     private function resolveNode(array $data, array $params) {
         if (isset($data[self::KEY_HYDRATE])) {
             $type = $data[self::KEY_HYDRATE];
+            if (!is_string($type)) {
+                $json = json_encode($type, JSON_PRETTY_PRINT);
+                $hydrateKey = self::KEY_HYDRATE;
+                throw new InvalidHydrateSpecException("The ${hydrateKey} must be a string. Instead got: $json");
+            }
             $resolver = $this->getResolver($type);
 
             $data = $resolver->resolve($data, $params);
@@ -271,6 +284,14 @@ class DataHydrator implements DataResolverInterface {
                     $r = $this->middleware->process($data, $params, $this->next);
                     return $r;
                 }
+
+                /**
+                 * @inheritDoc
+                 */
+                public function getType(): string {
+                    $class = get_class($this->middleware);
+                    return "middleware($class)";
+                }
             };
         }
         return $resolver;
@@ -304,6 +325,30 @@ class DataHydrator implements DataResolverInterface {
                 $r = ($this->resolver)($data, $params);
                 return $r;
             }
+
+            /**
+             * @inheritDoc
+             */
+            public function getType(): string {
+                $name = DataHydrator::getCallableName($this->resolver);
+                return "callable($name)";
+            }
         };
+    }
+
+    public static function getCallableName(callable $callable): string {
+        if (is_string($callable)) {
+            return trim($callable);
+        } elseif (is_array($callable)) {
+            if (is_object($callable[0])) {
+                return sprintf("%s::%s", get_class($callable[0]), trim($callable[1]));
+            } else {
+                return sprintf("%s::%s", trim($callable[0]), trim($callable[1]));
+            }
+        } elseif ($callable instanceof \Closure) {
+            return 'closure';
+        } else {
+            return 'unknown';
+        }
     }
 }

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -50,6 +50,9 @@ class DataHydrator {
      */
     private $resolver;
 
+    /** @var ParamResolver */
+    private $paramResolver;
+
     /**
      * DataHydrator constructor.
      */
@@ -57,15 +60,28 @@ class DataHydrator {
         $this->setExceptionHandler(new NullExceptionHandler());
 
         $this->addResolver(new LiteralResolver());
-        $this->addResolver(new ParamResolver());
+        $this->paramResolver = new ParamResolver();
+        $this->addResolver($this->paramResolver);
         $this->addResolver(new RefResolver());
         $this->addResolver(new SprintfResolver());
 
         $this->addMiddleware(new TransformMiddleware());
     }
 
+    /**
+     * @return ParamResolver
+     */
+    public function getParamResolver(): ParamResolver {
+        return $this->paramResolver;
+    }
+
+    /**
+     * Create a schema generator from all of our registered resolvers.
+     *
+     * @return JsonSchemaGenerator
+     */
     public function getSchemaGenerator(): JsonSchemaGenerator {
-        $generator = new JsonSchemaGenerator($this->resolvers, $this->middlewares);
+        $generator = new JsonSchemaGenerator($this->resolvers);
         return $generator;
     }
 

--- a/src/DataResolverInterface.php
+++ b/src/DataResolverInterface.php
@@ -21,4 +21,11 @@ interface DataResolverInterface {
      * @return mixed The resolver can return whatever it wants.
      */
     public function resolve(array $data, array $params = []);
+
+    /**
+     * Get the type of the resolver.
+     *
+     * @return string
+     */
+    public function getType(): string;
 }

--- a/src/Exception/InvalidHydrateSpecException.php
+++ b/src/Exception/InvalidHydrateSpecException.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @author Adam Charron <adam@charrondev.com>
+ * @copyright 2009-2021 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Hydrate\Exception;
+
+/**
+ * An exception for when a middleware that hasn't been registered is requested.
+ */
+class InvalidHydrateSpecException extends HydrateException {
+    /**
+     * MiddlewareNotFoundException constructor.
+     * @param string $message
+     */
+    public function __construct($message = "") {
+        parent::__construct($message, 400);
+    }
+}

--- a/src/ExceptionHandlerInterface.php
+++ b/src/ExceptionHandlerInterface.php
@@ -17,8 +17,8 @@ interface ExceptionHandlerInterface {
      * When implementing this method you want to either return new data that represents or fixes the exception or re-throw the exception.
      *
      * @param \Throwable $ex The exception that occurred.
-     * @param array $data The data that was being hyrdated.
-     * @param array $params The additional parameters passed when hyrdating.
+     * @param array $data The data that was being hydrated.
+     * @param array $params The additional parameters passed when hydrating.
      * @return mixed
      */
     public function handleException(\Throwable $ex, array $data, array $params);

--- a/src/MiddlewareWrapper.php
+++ b/src/MiddlewareWrapper.php
@@ -54,4 +54,11 @@ class MiddlewareWrapper implements DataResolverInterface {
         $r = $this->middleware->process($data, $allParams, $this->resolver);
         return $r;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string {
+        return 'middlewareWrapper';
+    }
 }

--- a/src/Resolvers/AbstractDataResolver.php
+++ b/src/Resolvers/AbstractDataResolver.php
@@ -7,7 +7,6 @@
 
 namespace Garden\Hydrate\Resolvers;
 
-use Garden\Hydrate\Schema\JsonSchemaGenerator;
 use Garden\Hydrate\ValidatableResolverInterface;
 use Garden\Schema\Schema;
 
@@ -58,13 +57,12 @@ abstract class AbstractDataResolver implements ValidatableResolverInterface {
     }
 
     /**
-     * If a string is used that will be the key to group the resolver.
+     * Define groups that the hydrator belongs to.
+     * Hydrators will always belong to the root hydrate group in addition to ones defined here.
      *
-     * Other items can allow properties to be only of a specific resolver group.
-     *
-     * @return string
+     * @return array
      */
-    public function getHydrateGroup(): string {
-        return JsonSchemaGenerator::ROOT_HYDRATE_GROUP;
+    public function getHydrateGroups(): array {
+        return [];
     }
 }

--- a/src/Resolvers/AbstractDataResolver.php
+++ b/src/Resolvers/AbstractDataResolver.php
@@ -65,6 +65,6 @@ abstract class AbstractDataResolver implements ValidatableResolverInterface {
      * @return string
      */
     public function getResolverGroup(): string {
-        return JsonSchemaGenerator::ROOT_GROUP;
+        return JsonSchemaGenerator::DEF_KEY_RESOLVER;
     }
 }

--- a/src/Resolvers/AbstractDataResolver.php
+++ b/src/Resolvers/AbstractDataResolver.php
@@ -60,7 +60,10 @@ abstract class AbstractDataResolver implements ValidatableResolverInterface {
      * Define groups that the hydrator belongs to.
      * Hydrators will always belong to the root hydrate group in addition to ones defined here.
      *
-     * @return array
+     * This is meant to be used alongside the x-hydrate-group schema parameter when creating HydrateableSchema.
+     * Only resolvers that return that given type would be allowed on that particular property (as opposed to any resolver at all).
+     *
+     * @return string[]
      */
     public function getHydrateGroups(): array {
         return [];

--- a/src/Resolvers/AbstractDataResolver.php
+++ b/src/Resolvers/AbstractDataResolver.php
@@ -64,7 +64,7 @@ abstract class AbstractDataResolver implements ValidatableResolverInterface {
      *
      * @return string
      */
-    public function getResolverGroup(): string {
-        return JsonSchemaGenerator::DEF_KEY_RESOLVER;
+    public function getHydrateGroup(): string {
+        return JsonSchemaGenerator::ROOT_HYDRATE_GROUP;
     }
 }

--- a/src/Resolvers/AbstractDataResolver.php
+++ b/src/Resolvers/AbstractDataResolver.php
@@ -7,6 +7,7 @@
 
 namespace Garden\Hydrate\Resolvers;
 
+use Garden\Hydrate\Schema\JsonSchemaGenerator;
 use Garden\Hydrate\ValidatableResolverInterface;
 use Garden\Schema\Schema;
 
@@ -48,4 +49,22 @@ abstract class AbstractDataResolver implements ValidatableResolverInterface {
      * @return mixed
      */
     abstract protected function resolveInternal(array $data, array $params);
+
+    /**
+     * @return Schema|null
+     */
+    public function getSchema(): ?Schema {
+        return $this->schema;
+    }
+
+    /**
+     * If a string is used that will be the key to group the resolver.
+     *
+     * Other items can allow properties to be only of a specific resolver group.
+     *
+     * @return string
+     */
+    public function getResolverGroup(): string {
+        return JsonSchemaGenerator::ROOT_GROUP;
+    }
 }

--- a/src/Resolvers/FunctionResolver.php
+++ b/src/Resolvers/FunctionResolver.php
@@ -62,6 +62,10 @@ class FunctionResolver extends AbstractDataResolver {
         $properties = [];
         $required = [];
 
+        $funcName = $func->getName();
+        if ($func instanceof ReflectionMethod) {
+            $funcName = $func->getDeclaringClass()->getName() . '::' . $funcName;
+        }
         foreach ($func->getParameters() as $param) {
             if ($param->isVariadic()) {
                 $variadic = $param->getName();
@@ -107,9 +111,11 @@ class FunctionResolver extends AbstractDataResolver {
 
             $properties[$param->getName()] = $schema;
         }
+        $propertiesName = implode(", ", array_keys($properties));
 
         $schema = Schema::parse([
             'type' => 'object',
+            'description' => "Call the function `$funcName($propertiesName)`",
             'properties' => $properties,
             'required' => $required,
         ]);

--- a/src/Resolvers/FunctionResolver.php
+++ b/src/Resolvers/FunctionResolver.php
@@ -40,7 +40,7 @@ class FunctionResolver extends AbstractDataResolver {
      * ReflectedFunctionResolver constructor.
      *
      * @param callable $function The function that will resolve the data.
-     * @param string $resolverType A name to use as the resolver type. If left empty one will be generated.
+     * @param string|null $resolverType A name to use as the resolver type. If left empty one will be generated.
      */
     public function __construct(callable $function, string $resolverType = null) {
         $this->function = $function;

--- a/src/Resolvers/LiteralResolver.php
+++ b/src/Resolvers/LiteralResolver.php
@@ -24,16 +24,16 @@ class LiteralResolver extends AbstractDataResolver {
      */
     public function __construct() {
         $this->schema = new Schema([
-            'description' => 'A literal returns it\'s exact exact value.'
-                .'For objects you can add additional properties, but for other types you can set data to be that value.',
+            'description' => 'A literal returns it\'s exact data value before any other processing.',
             'type' => 'object',
             'properties' => [
                 'data' => [
-                    'description' => 'A literal returns it\'s exact exact value.'
-                        .'For objects you can add additional properties, but for other types you can set data to be that value.',
+                    HydrateableSchema::X_NO_HYDRATE => true,
+                    'description' => 'The value of the literal',
                     'type' => HydrateableSchema::ALL_SCHEMA_TYPES,
                 ],
             ],
+            'required' => ['data'],
         ]);
     }
 
@@ -45,12 +45,7 @@ class LiteralResolver extends AbstractDataResolver {
      * @return mixed
      */
     public function resolveInternal(array $data, array $params) {
-        if (isset($data['data'])) {
-            return $data['data'];
-        } else {
-            unset($data[DataHydrator::KEY_HYDRATE]);
-            return $data;
-        }
+        return $data['data'];
     }
 
     /**

--- a/src/Resolvers/LiteralResolver.php
+++ b/src/Resolvers/LiteralResolver.php
@@ -8,6 +8,7 @@
 namespace Garden\Hydrate\Resolvers;
 
 use Garden\Hydrate\DataHydrator;
+use Garden\Hydrate\Schema\HydrateableSchema;
 use Garden\Hydrate\Schema\JsonSchemaGenerator;
 use Garden\Schema\Schema;
 
@@ -23,10 +24,14 @@ class LiteralResolver extends AbstractDataResolver {
      */
     public function __construct() {
         $this->schema = new Schema([
+            'description' => 'A literal returns it\'s exact exact value.'
+                .'For objects you can add additional properties, but for other types you can set data to be that value.',
             'type' => 'object',
             'properties' => [
                 'data' => [
-                    'type' => JsonSchemaGenerator::ALL_SCHEMA_TYPES,
+                    'description' => 'A literal returns it\'s exact exact value.'
+                        .'For objects you can add additional properties, but for other types you can set data to be that value.',
+                    'type' => HydrateableSchema::ALL_SCHEMA_TYPES,
                 ],
             ],
         ]);

--- a/src/Resolvers/LiteralResolver.php
+++ b/src/Resolvers/LiteralResolver.php
@@ -7,12 +7,17 @@
 
 namespace Garden\Hydrate\Resolvers;
 
+use Garden\Hydrate\DataHydrator;
+use Garden\Hydrate\Schema\JsonSchemaGenerator;
 use Garden\Schema\Schema;
 
 /**
  * A resolver that allows for a literal value.
  */
 class LiteralResolver extends AbstractDataResolver {
+
+    public const TYPE = "literal";
+
     /**
      * LiteralResolver constructor.
      */
@@ -20,9 +25,10 @@ class LiteralResolver extends AbstractDataResolver {
         $this->schema = new Schema([
             'type' => 'object',
             'properties' => [
-                'data' => [],
+                'data' => [
+                    'type' => JsonSchemaGenerator::ALL_SCHEMA_TYPES,
+                ],
             ],
-            'required' => ['data'],
         ]);
     }
 
@@ -34,6 +40,18 @@ class LiteralResolver extends AbstractDataResolver {
      * @return mixed
      */
     public function resolveInternal(array $data, array $params) {
-        return $data['data'];
+        if (isset($data['data'])) {
+            return $data['data'];
+        } else {
+            unset($data[DataHydrator::KEY_HYDRATE]);
+            return $data;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string {
+        return self::TYPE;
     }
 }

--- a/src/Resolvers/ParamResolver.php
+++ b/src/Resolvers/ParamResolver.php
@@ -14,7 +14,10 @@ use Garden\Schema\Schema;
  * A resolver that grabs its data from passed parameters.
  */
 final class ParamResolver extends AbstractDataResolver {
+
     use ReferenceResolverTrait;
+
+    public const TYPE = "param";
 
     /**
      * ParamResolver constructor.
@@ -43,5 +46,12 @@ final class ParamResolver extends AbstractDataResolver {
 
         $result = $this->resolveReference($ref, $params, $params, $found);
         return $found ? $result : $default;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string {
+        return self::TYPE;
     }
 }

--- a/src/Resolvers/ParamResolver.php
+++ b/src/Resolvers/ParamResolver.php
@@ -51,7 +51,9 @@ final class ParamResolver extends AbstractDataResolver {
      * @param string[] $paramNames
      */
     public function setParamNames(array $paramNames) {
-        $this->schema->setField('properties.ref.enum', $paramNames);
+        if ($this->schema !== null) {
+            $this->schema->setField('properties.ref.enum', $paramNames);
+        }
     }
 
     /**

--- a/src/Resolvers/ParamResolver.php
+++ b/src/Resolvers/ParamResolver.php
@@ -26,13 +26,16 @@ final class ParamResolver extends AbstractDataResolver {
      */
     public function __construct() {
         $this->schema = new Schema([
-            'description' => 'Params are data passed in during rendering. In order to ',
+            'description' => 'Params are data passed in during hydration.',
             'type' => 'object',
             'properties' => [
                 'ref' => [
+                    'description' => 'The parameter name.',
                     'type' => 'string',
+                    HydrateableSchema::X_NO_HYDRATE => true,
                 ],
                 'default' => [
+                    'description' => 'A default value for the parameter value. Defaults to null.',
                     'type' => HydrateableSchema::ALL_SCHEMA_TYPES,
                     'default' => null,
                 ],

--- a/src/Resolvers/ParamResolver.php
+++ b/src/Resolvers/ParamResolver.php
@@ -7,6 +7,8 @@
 
 namespace Garden\Hydrate\Resolvers;
 
+use Garden\Hydrate\Schema\HydrateableSchema;
+use Garden\Hydrate\Schema\JsonSchemaGenerator;
 use Garden\JSON\ReferenceResolverTrait;
 use Garden\Schema\Schema;
 
@@ -24,17 +26,29 @@ final class ParamResolver extends AbstractDataResolver {
      */
     public function __construct() {
         $this->schema = new Schema([
+            'description' => 'Params are data passed in during rendering. In order to ',
             'type' => 'object',
             'properties' => [
                 'ref' => [
                     'type' => 'string',
                 ],
                 'default' => [
-
+                    'type' => HydrateableSchema::ALL_SCHEMA_TYPES,
+                    'default' => null,
                 ],
             ],
             'required' => ['ref'],
         ]);
+    }
+
+
+    /**
+     * Set valid parameter names.
+     *
+     * @param string[] $paramNames
+     */
+    public function setParamNames(array $paramNames) {
+        $this->schema->setField('properties.ref.enum', $paramNames);
     }
 
     /**

--- a/src/Resolvers/RefResolver.php
+++ b/src/Resolvers/RefResolver.php
@@ -8,11 +8,12 @@
 namespace Garden\Hydrate\Resolvers;
 
 use Garden\Hydrate\DataHydrator;
+use Garden\Hydrate\Schema\HydrateableSchema;
 use Garden\JSON\ReferenceResolverTrait;
 use Garden\Schema\Schema;
 
 /**
- * A resolver that can reference he entire data array.
+ * A resolver that can reference the entire data array.
  */
 final class RefResolver extends AbstractDataResolver {
 
@@ -26,13 +27,18 @@ final class RefResolver extends AbstractDataResolver {
     public function __construct() {
         $this->schema = new Schema([
             'type' => 'object',
+            'description' => 'Reference data from other parts of the hydration by it\'s path.',
             'properties' => [
                 'ref' => [
+                    'description' => 'A local reference within the document. For example: "/path/to/property/from/root".',
                     'type' => 'string',
+                    HydrateableSchema::X_NO_HYDRATE => true,
                 ],
                 'default' => [
-
-                ],
+                    'description' => 'Default value if the ref could not be resolved. Defaults to null.',
+                    'type' => HydrateableSchema::ALL_SCHEMA_TYPES,
+                    'default' => null,
+                ]
             ],
             'required' => ['ref'],
         ]);

--- a/src/Resolvers/RefResolver.php
+++ b/src/Resolvers/RefResolver.php
@@ -15,7 +15,10 @@ use Garden\Schema\Schema;
  * A resolver that can reference he entire data array.
  */
 final class RefResolver extends AbstractDataResolver {
+
     use ReferenceResolverTrait;
+
+    public const TYPE = "ref";
 
     /**
      * RefResolver constructor.
@@ -44,5 +47,12 @@ final class RefResolver extends AbstractDataResolver {
 
         $result = $this->resolveReference($ref, $data, $params[DataHydrator::KEY_ROOT] ?? [], $found);
         return $found ? $result : $default;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string {
+        return self::TYPE;
     }
 }

--- a/src/Resolvers/SprintfResolver.php
+++ b/src/Resolvers/SprintfResolver.php
@@ -13,6 +13,9 @@ use Garden\Schema\Schema;
  * A data resolver that calls `sprintf()`.
  */
 class SprintfResolver extends AbstractDataResolver {
+
+    public const TYPE = "sprintf";
+
     /**
      * SprintfResolver constructor.
      */
@@ -34,5 +37,12 @@ class SprintfResolver extends AbstractDataResolver {
         $args = $data['args'] ?? [];
         $result = sprintf($data['format'], ...$args);
         return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string {
+        return self::TYPE;
     }
 }

--- a/src/Resolvers/SprintfResolver.php
+++ b/src/Resolvers/SprintfResolver.php
@@ -22,9 +22,16 @@ class SprintfResolver extends AbstractDataResolver {
     public function __construct() {
         $this->schema = new Schema([
             'type' => 'object',
+            'description' => 'Call sprintf($format, $args).',
             'properties' => [
-                'format' => ['type' => 'string'],
-                'args' => ['type' => 'array'],
+                'format' => [
+                    'description' => 'The format string.',
+                    'type' => 'string',
+                ],
+                'args' => [
+                    'description' => 'Arguments to interpolate into the format string.',
+                    'type' => 'array',
+                ],
             ],
             'required' => ['format'],
         ]);

--- a/src/Schema/HydrateableSchema.php
+++ b/src/Schema/HydrateableSchema.php
@@ -81,15 +81,9 @@ class HydrateableSchema extends Schema {
     }
 
     /**
-     * Parsing factory.
+     * @inheritdoc
      *
-     * @param array $arr The schema array to use.
-     * @param string $ownHydrateType The key of our own data resolver.
-     * @param array $hydrateTypesByGroup A mapping of available hydrate types to their groups.
-     *
-     * @return static Return a new schema.
-     *
-     * @throws InvalidHydrateSpecException If the root type does not allow an object.
+     * @psalm-suppress LessSpecificReturnStatement
      */
     public static function parse(array $arr, ...$args) {
         // We can't use parse directly because $schema is private and we can't modify it in a subclass after being instantiated.
@@ -227,9 +221,9 @@ class HydrateableSchema extends Schema {
     /**
      * Push into or create a 'required' property on the given array.
      *
-     * @param array|Schema $someArray The array to mark a required property on.
+     * @param array $someArray The array to mark a required property on.
      */
-    private function markHydrateRequired(&$someArray) {
+    private function markHydrateRequired(array &$someArray) {
         $someArray['required'] = array_unique(array_merge(
             $someArray['required'] ?? [],
             [DataHydrator::KEY_HYDRATE]

--- a/src/Schema/HydrateableSchema.php
+++ b/src/Schema/HydrateableSchema.php
@@ -81,8 +81,9 @@ class HydrateableSchema extends Schema {
     }
 
     /**
-     * @inheritdoc
+     * Parse a short schema and return the associated schema.
      *
+     * @inheritdoc
      * @psalm-suppress LessSpecificReturnStatement
      */
     public static function parse(array $arr, ...$args) {

--- a/src/Schema/HydrateableSchema.php
+++ b/src/Schema/HydrateableSchema.php
@@ -53,15 +53,17 @@ class HydrateableSchema extends Schema {
     /**
      * Constructor
      *
-     * @param Schema|array $schemaArray The schema array to use.
+     * @param Schema|array $schemaOrArray The schema array to use.
      * @param string $ownHydrateType The key of our own data resolver.
      * @param array $hydrateTypesByGroup A mapping of available hydrate types to their groups.
      *
      * @throws InvalidHydrateSpecException If the root type does not allow an object.
      */
-    public function __construct($schemaArray, string $ownHydrateType, array $hydrateTypesByGroup = []) {
-        if ($schemaArray instanceof Schema) {
-            $schemaArray = $schemaArray->getSchemaArray();
+    public function __construct($schemaOrArray, string $ownHydrateType, array $hydrateTypesByGroup = []) {
+        if ($schemaOrArray instanceof Schema) {
+            $schemaArray = $schemaOrArray->getSchemaArray();
+        } else {
+            $schemaArray = $schemaOrArray;
         }
         $this->hydrateTypesByGroup = $hydrateTypesByGroup;
         $this->ownHydrateType = $ownHydrateType;

--- a/src/Schema/HydrateableSchema.php
+++ b/src/Schema/HydrateableSchema.php
@@ -53,18 +53,13 @@ class HydrateableSchema extends Schema {
     /**
      * Constructor
      *
-     * @param Schema|array $schemaOrArray The schema array to use.
+     * @param array $schemaArray The schema array to use.
      * @param string $ownHydrateType The key of our own data resolver.
      * @param array $hydrateTypesByGroup A mapping of available hydrate types to their groups.
      *
      * @throws InvalidHydrateSpecException If the root type does not allow an object.
      */
-    public function __construct($schemaOrArray, string $ownHydrateType, array $hydrateTypesByGroup = []) {
-        if ($schemaOrArray instanceof Schema) {
-            $schemaArray = $schemaOrArray->getSchemaArray();
-        } else {
-            $schemaArray = $schemaOrArray;
-        }
+    public function __construct(array $schemaArray, string $ownHydrateType, array $hydrateTypesByGroup = []) {
         $this->hydrateTypesByGroup = $hydrateTypesByGroup;
         $this->ownHydrateType = $ownHydrateType;
 
@@ -83,6 +78,24 @@ class HydrateableSchema extends Schema {
         $schemaArray = $this->allowHydrateInSchema($schemaArray);
         $this->markHydrateRequired($schemaArray);
         parent::__construct($schemaArray);
+    }
+
+    /**
+     * Parsing factory.
+     *
+     * @param array $arr The schema array to use.
+     * @param string $ownHydrateType The key of our own data resolver.
+     * @param array $hydrateTypesByGroup A mapping of available hydrate types to their groups.
+     *
+     * @return static Return a new schema.
+     *
+     * @throws InvalidHydrateSpecException If the root type does not allow an object.
+     */
+    public static function parse(array $arr, ...$args) {
+        // We can't use parse directly because $schema is private and we can't modify it in a subclass after being instantiated.
+        $parsed = Schema::parse($arr);
+        $hydrateable = new HydrateableSchema($parsed->getSchemaArray(), ...$args);
+        return $hydrateable;
     }
 
     /**

--- a/src/Schema/HydrateableSchema.php
+++ b/src/Schema/HydrateableSchema.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * @author Adam Charron <adam@charrondev.com>
+ * @copyright 2009-2021 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Hydrate\Schema;
+
+use Garden\Hydrate\DataHydrator;
+use Garden\Schema\Schema;
+
+/**
+ * A schema that allows any subfields to be recursively hydrated.
+ */
+class HydrateableSchema extends Schema {
+
+    /** @var string[] All built-in schema types in JSON schema. */
+    public const ALL_SCHEMA_TYPES = [
+        'array',
+        'object',
+        'integer',
+        'string',
+        'number',
+        'boolean',
+        'timestamp',
+        'datetime',
+        'null',
+    ];
+
+    public const ANY_OBJECT_SCHEMA_ARRAY = [
+        'type' => 'object',
+        'allowAdditionalProperties' => true,
+    ];
+
+    /** @var string[] */
+    private $hydrateTypes;
+
+    /** @var string */
+    private $ownHydrateType;
+
+    /**
+     * Constructor
+     *
+     * @param array $schema The schema array to use.
+     * @param string $ownHydrateType The key of our own data resolver.
+     * @param array $hydrateTypes An array of all hydrate types. This is needed for recursive property typing.
+     */
+    public function __construct(array $schema, string $ownHydrateType, array $hydrateTypes = []) {
+        $this->hydrateTypes = $hydrateTypes;
+        $this->ownHydrateType = $ownHydrateType;
+        // Make sure hydrate key is required.
+        $schema['properties'] = $schema['properties'] ?? [];
+        $schema['properties'][DataHydrator::KEY_HYDRATE] = [
+            'type' => 'string',
+            'enum' => [$this->ownHydrateType],
+        ];
+        $schema = $this->allowHydrateInSchema($schema);
+        $this->markHydrateRequired($schema);
+        parent::__construct($schema);
+    }
+
+    /**
+     * Allow hydrate in a schema.
+     *
+     * @param array $schemaArray
+     *
+     * @return array
+     */
+    private function allowHydrateInSchema(array $schemaArray): array {
+        if (isset($schemaArray['properties'])) {
+            // This is a hydrate spec.
+            // We allow hydrate on everything but the hydrate key.
+            $newProperties = [];
+            $hasHydrate = false;
+            foreach ($schemaArray['properties'] as $key => $property) {
+                if ($key === DataHydrator::KEY_HYDRATE) {
+                    $hasHydrate = true;
+                    $newProperties[$key] = $property;
+                } else {
+                    $newProperties[$key] = $this->allowHydrateInSchema($property);
+                }
+            }
+            $schemaArray['properties'] = $newProperties;
+            if (!$hasHydrate) {
+                $schemaArray = $this->oneOfWithHydrate($schemaArray);
+            }
+        } elseif (isset($schemaArray['oneOf'])) {
+            // We already have a oneOf.
+            // Modify the existing items
+            $items = $schemaArray['oneOf'];
+            $items[] = JsonSchemaGenerator::REF_RESOLVER;
+
+            // Push into it.
+            $schemaArray['oneOf'] = $items;
+        } elseif (isset($schemaArray['anyOf'])) {
+            // Modify the existing items
+            $items = array_map([$this, 'oneOfWithHydrate'], $schemaArray['anyOf']);
+
+            // Wrap ourselves so we are { oneOf: [ {anyOf: }, REF_RESOLVER ] }
+            $oneOf = $this->oneOfWithHydrate([
+                'anyOf' => $items
+            ]);
+            unset($schemaArray['anyOf']);
+            $schemaArray = array_merge_recursive($schemaArray, $oneOf);
+        } else {
+            // addHydrateDiscriminator is required if there is a different possible object type here (then $literal is needed).
+            // Normally by this point we've already ruled out object types and wouldn't need this, unless the item is a ref.
+            // If it's a ref, it could be anything.
+            $schemaArray = $this->oneOfWithHydrate($schemaArray);
+        }
+        return $schemaArray;
+    }
+
+    /**
+     * Take a schema array an union it with the
+     *
+     * @param array $schemaArray
+     * @return array[]
+     */
+    private function oneOfWithHydrate(array $schemaArray): array {
+        // Clear the description, we're hoisting it.
+        $description = $schemaArray['description'] ?? null;
+        unset($schemaArray['description']);
+        $schemaArray = [
+            'oneOf' => [
+                $schemaArray,
+                JsonSchemaGenerator::REF_RESOLVER,
+            ]
+        ];
+        // Put back the description if there was one.
+        if ($description !== null) {
+            $schemaArray['description'] = $description;
+        }
+
+        // Add a discriminator field for autocomplete.
+        foreach ($schemaArray['oneOf'] as $of) {
+            $ofRef = $of['$ref'] ?? null;
+            if ($ofRef === JsonSchemaGenerator::REF_RESOLVER['$ref']) {
+                break;
+            }
+        }
+        // Currently this CANNOT be a reference.
+        // Most autocompleting tools require this level of verbosity to not fall apart.
+        $schemaArray['properties'] = [
+            DataHydrator::KEY_HYDRATE => [
+                'type' => 'string',
+                'enum' => $this->hydrateTypes,
+            ]
+        ];
+        $this->markHydrateRequired($schemaArray);
+
+        return $schemaArray;
+    }
+
+    /**
+     * Push into or create a 'required' property on the given array.
+     *
+     * @param array|Schema $someArray The array to mark a required property on.
+     */
+    private function markHydrateRequired(&$someArray) {
+        $someArray['required'] = array_unique(array_merge(
+            $someArray['required'] ?? [],
+            [DataHydrator::KEY_HYDRATE]
+        ));
+    }
+}

--- a/src/Schema/JsonSchemaGenerator.php
+++ b/src/Schema/JsonSchemaGenerator.php
@@ -63,8 +63,10 @@ class JsonSchemaGenerator {
         // We need to know all the types before we build our references.
         foreach ($this->resolvers as $resolver) {
             $type = $resolver->getType();
-            $group = $resolver->getHydrateGroup();
-            $this->pushTypeAndGroup($type, $group);
+            $groups = $resolver->getHydrateGroups();
+            foreach ($groups as $group) {
+                $this->pushTypeAndGroup($type, $group);
+            }
             $this->pushTypeAndGroup($type, self::ROOT_HYDRATE_GROUP);
         }
         $this->allTypes = array_map(function (AbstractDataResolver $resolver) {

--- a/src/Schema/JsonSchemaGenerator.php
+++ b/src/Schema/JsonSchemaGenerator.php
@@ -151,7 +151,6 @@ class JsonSchemaGenerator {
         $schemaArray = $schema ? $schema->getSchemaArray() : HydrateableSchema::ANY_OBJECT_SCHEMA_ARRAY;
         $hydrateableSchema = new HydrateableSchema($schemaArray, $type, $this->typesByGroup);
         $this->referencesByType[$type] = $hydrateableSchema->getSchemaArray();
-
     }
 
     /**

--- a/src/Schema/JsonSchemaGenerator.php
+++ b/src/Schema/JsonSchemaGenerator.php
@@ -99,7 +99,8 @@ class JsonSchemaGenerator {
                         'type' => 'string',
                         'enum' => $this->allTypes,
                     ]
-                ]
+                ],
+                'required' => [DataHydrator::KEY_HYDRATE]
             ];
         }
 

--- a/src/Schema/JsonSchemaGenerator.php
+++ b/src/Schema/JsonSchemaGenerator.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * @author Adam Charron <adam@charrondev.com>
+ * @copyright 2009-2021 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Hydrate\Schema;
+
+use Garden\Hydrate\DataHydrator;
+use Garden\Hydrate\ExceptionHandlerInterface;
+use Garden\Hydrate\MiddlewareInterface;
+use Garden\Hydrate\Resolvers\AbstractDataResolver;
+use Garden\Hydrate\Resolvers\LiteralResolver;
+use Garden\Schema\Schema;
+
+/**
+ * Class for generating a schema out of a group of resolvers.
+ */
+class JsonSchemaGenerator {
+
+    public const SCHEMA_DRAFT_7_URL = "http://json-schema.org/draft-07/schema";
+
+    /** @var string The definition key used for the combined resolver types. */
+    public const DEF_KEY_RESOLVER = 'resolver';
+
+    /** @var string[] A reference to all resolver types. */
+    private const REF_RESOLVER = [
+        '$ref' => '#/$defs/' . self::DEF_KEY_RESOLVER
+    ];
+
+    /** @var string[] All built-in schema types in JSON schema. */
+    public const ALL_SCHEMA_TYPES = [
+        'array',
+        'object',
+        'integer',
+        'string',
+        'number',
+        'boolean',
+        'timestamp',
+        'datetime',
+        'null',
+    ];
+
+    /** @var AbstractDataResolver[] */
+    private $resolvers;
+
+    /** @var MiddlewareInterface[] */
+    private $middlewares;
+
+    /**
+     * An array of all the resolver types.
+     * Why these and not just array_keys($referencesByType)?
+     * We need to know all possible types in order to generate any reference.
+     * @var string[]
+     */
+    private $allTypes = [];
+
+    /**
+     * Store all the JSON schema references by their resolver type.
+     * @var array[]
+     */
+    private $referencesByType = [];
+
+    /**
+     * Keep a mapping of all resolver groups to the types in them.
+     *
+     * @var array[]
+     */
+    private $typesByGroup = [
+        'resolver' => [],
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param AbstractDataResolver[] $resolvers
+     * @param MiddlewareInterface[] $middlewares
+     */
+    public function __construct(array $resolvers, array $middlewares) {
+        $this->resolvers = $resolvers;
+
+        // We need to know all the types before we build our references.
+        $this->allTypes = array_map(function (AbstractDataResolver $resolver) {
+            return $resolver->getType();
+        }, $resolvers);
+
+        // Now we can build the references.
+        foreach ($this->resolvers as $resolver) {
+            $this->applyResolverAsReference($resolver);
+        }
+
+        $this->middlewares = $middlewares;
+    }
+
+    /**
+     * Get a schema with all resolver definitions and with allowing any structure of resolvers.
+     *
+     * @return Schema
+     */
+    public function getDefaultSchema(): Schema {
+        $schema = new Schema(self::REF_RESOLVER);
+        $schema->setField('$schema', self::SCHEMA_DRAFT_7_URL);
+        $schema->setField('$defs', $this->createCombinedDefsArray());
+        return $schema;
+    }
+
+    /**
+     * Create an array of all resolver definitions to be used as a references.
+     *
+     * @return array
+     */
+    private function createCombinedDefsArray(): array {
+        $defs = [];
+        // Make sure we have defs for groups of things (included the root group that contains everything).
+        foreach ($this->typesByGroup as $group => $types) {
+            $defs[$group] = [
+                'oneOf' => array_map([JsonSchemaGenerator::class, 'getDefReference'], $types),
+            ];
+        }
+
+        // Add the individual items as refs.
+        foreach ($this->referencesByType as $ref => $type) {
+            $defs[$ref] = $type;
+        }
+        return $defs;
+    }
+
+    /**
+     * Given the key of a definition, get an array referencing it.
+     *
+     * @param string $defKey The key of the definition. For example 'literal'.
+     *
+     * @return array The reference.
+     */
+    private static function getDefReference(string $defKey): array {
+        return [
+            '$ref' => '#/$defs/' . $defKey,
+        ];
+    }
+
+    private function addHydrateToSchema() {}
+
+    private function applyResolverAsReference(AbstractDataResolver $resolver) {
+        $type = $resolver->getType();
+        $schema = $resolver->getSchema() ?? self::makeNullSchemaArray($type);
+        $schema->setField(['properties', DataHydrator::KEY_HYDRATE], [
+            'type' => 'string',
+            'enum' => [$type],
+        ]);
+        // Make sure hydrate key is required.
+        $schema->setField(
+            'required',
+            array_unique(array_merge(
+                $schema->getField('required', []),
+                [DataHydrator::KEY_HYDRATE]
+            ))
+        );
+
+        $group = $resolver->getResolverGroup();
+        $this->referencesByType[$type] = $this->allowHydrateInSchema(
+            $schema->getSchemaArray()
+        );
+        $this->pushTypeAndGroup($type, $group);
+        $this->pushTypeAndGroup($type, self::DEF_KEY_RESOLVER);
+    }
+
+    private function allowHydrateInSchema(array $schemaArray): array {
+        if (isset($schemaArray['properties'][DataHydrator::KEY_HYDRATE])) {
+            // This is a hydrate spec.
+            // We allow hydrate on everything but the hydrate key.
+            $newProperties = [
+//                DataHydrator::KEY_HYDRATE => $schemaArray['properties'][DataHydrator::KEY_HYDRATE],
+            ];
+            foreach ($schemaArray['properties'] as $key => $property) {
+                if ($key === DataHydrator::KEY_HYDRATE) {
+                    $newProperties[$key] = $property;
+                } else {
+                    $newProperties[$key] = $this->allowHydrateInSchema($property);
+                }
+            }
+            $schemaArray['properties'] = $newProperties;
+        } elseif (isset($schemaArray['oneOf'])) {
+            // We already have a oneOf.
+            // Modify the existing items
+            $items = array_map([$this, 'oneOfOrResolve'], $schemaArray['oneOf']);
+            $items[] = self::REF_RESOLVER;
+
+            // Push into it.
+            $schemaArray['oneOf'] = $items;
+        } elseif (isset($schemaArray['anyOf'])) {
+            // Modify the existing items
+            $items = array_map([$this, 'oneOfOrResolve'], $schemaArray['anyOf']);
+
+            // Wrap ourselves so we are { oneOf: [ {anyOf: }, REF_RESOLVER ] }
+            $oneOf = $this->oneOfOrResolve([
+                'anyOf' => $items
+            ]);
+            unset($schemaArray['anyOf']);
+            $schemaArray = array_merge_recursive($schemaArray, $oneOf);
+        } elseif (isset($schemaArray['properties'])) {
+            $modified = [];
+            foreach ($schemaArray['properties'] as $property => $definition) {
+                $modified[$property] = $this->allowHydrateInSchema($definition);
+            }
+            $schemaArray = $this->oneOfOrResolve($modified);
+        } else {
+            $schemaArray = $this->oneOfOrResolve($schemaArray);
+        }
+        $schemaArray = $this->patchOneOf($schemaArray);
+        return $schemaArray;
+    }
+
+    /**
+     * Ensure that we have a clear discriminator property to go with a hydrate oneOf.
+     *
+     * Essentially most language services will not go find properties to autocomplete until you've chosen your discriminator.
+     *
+     * @see https://github.com/microsoft/vscode-json-languageservice/issues/86#issuecomment-820984129
+     *
+     * @param array $schemaArray
+     * @return array
+     */
+    private function patchOneOf(array $schemaArray): array {
+        if (isset($schemaArray['oneOf'])) {
+            $hydrateAll = false;
+            foreach ($schemaArray['oneOf'] as $of) {
+                $ofRef = $of['$ref'] ?? null;
+                if ($ofRef === self::REF_RESOLVER['$ref']) {
+                    $hydrateAll = true;
+                    break;
+                }
+            }
+            if ($hydrateAll) {
+                // Currently this CANNOT be a reference.
+                // Most autocompleting tools require this level of verbosity to not fall apart.
+                $schemaArray['properties'] = [
+                    DataHydrator::KEY_HYDRATE => [
+                        'type' => 'string',
+                        'enum' => $this->allTypes,
+                    ]
+                ];
+                // Make sure it's required
+                $schemaArray['required'] = array_unique(array_merge(
+                    $allHydrateValues['required'] ?? [],
+                    [DataHydrator::KEY_HYDRATE]
+                ));
+            }
+        }
+        return $schemaArray;
+    }
+
+    private function oneOfOrResolve(array $typeArray): array {
+        return [
+            'oneOf' => [
+                $typeArray,
+                self::REF_RESOLVER,
+            ]
+        ];
+    }
+
+    /**
+     * Track references between a type and group.
+     *
+     * @param string $type
+     * @param string $group
+     */
+    private function pushTypeAndGroup(string $type, string $group) {
+        $this->typesByGroup[$group] = array_unique(array_merge(
+            $this->typesByGroup[$group] ?? [],
+            [$type]
+        ));
+    }
+
+    private function makeNullSchemaArray(string $type): Schema {
+        return Schema::parse([
+            'type' => 'object',
+            'allowAdditionalProperties' => true,
+            'required' => [DataHydrator::KEY_HYDRATE],
+        ]);
+    }
+}

--- a/tests/DataHydratorTest.php
+++ b/tests/DataHydratorTest.php
@@ -30,8 +30,8 @@ class DataHydratorTest extends TestCase {
         $this->hydrator = new DataHydrator();
         $this->hydrator
             ->setExceptionHandler(new TestExceptionHandler())
-            ->addResolver('exception', new ExceptionThrowerResolver())
-            ->addResolver('str', new TestStringResolver('a'));
+            ->addResolver(new ExceptionThrowerResolver())
+            ->addResolver(new TestStringResolver('a'));
     }
 
     /**

--- a/tests/Fixtures/ExceptionThrowerResolver.php
+++ b/tests/Fixtures/ExceptionThrowerResolver.php
@@ -8,15 +8,23 @@
 namespace Garden\Hydrate\Tests\Fixtures;
 
 use Garden\Hydrate\DataResolverInterface;
+use Garden\Hydrate\Resolvers\AbstractDataResolver;
 
 /**
  * A data resolver that just throws exceptions.
  */
-class ExceptionThrowerResolver implements DataResolverInterface {
+class ExceptionThrowerResolver extends AbstractDataResolver {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
-    public function resolve(array $data, array $params = []) {
+    public function resolveInternal(array $data, array $params = []) {
         throw new \Exception($data['message'], $data['code'] ?? 500);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string {
+        return 'exception';
     }
 }

--- a/tests/Fixtures/TestStringResolver.php
+++ b/tests/Fixtures/TestStringResolver.php
@@ -37,4 +37,11 @@ class TestStringResolver extends AbstractDataResolver {
 
         return $data;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string {
+        return 'str';
+    }
 }

--- a/tests/Fixtures/TestTypeGroupResolver.php
+++ b/tests/Fixtures/TestTypeGroupResolver.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @author Adam Charron <adam@charrondev.com>
+ * @copyright 2009-2021 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Hydrate\Tests\Fixtures;
+
+use Garden\Hydrate\Resolvers\AbstractDataResolver;
+
+/**
+ * A test resolver that adds a string to the data.
+ */
+class TestTypeGroupResolver extends AbstractDataResolver {
+    /**
+     * @var string
+     */
+    private $type;
+
+    /** @var string|null */
+    private $hydrateGroup;
+
+    /**
+     * TestStringResolver constructor.
+     *
+     * @param string $type
+     * @param string|null $hydrateGroup
+     */
+    public function __construct(string $type, string $hydrateGroup = null) {
+        $this->type = $type;
+        $this->hydrateGroup = $hydrateGroup;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function resolveInternal(array $data, array $params = []) {
+        return 'testTypeGroup';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHydrateGroup(): string {
+        if ($this->hydrateGroup === null) {
+            return parent::getHydrateGroup();
+        } else {
+            return $this->hydrateGroup;
+        }
+    }
+}

--- a/tests/Fixtures/TestTypeGroupResolver.php
+++ b/tests/Fixtures/TestTypeGroupResolver.php
@@ -18,18 +18,18 @@ class TestTypeGroupResolver extends AbstractDataResolver {
      */
     private $type;
 
-    /** @var string|null */
-    private $hydrateGroup;
+    /** @var string[]|null */
+    private $hydrateGroups;
 
     /**
      * TestStringResolver constructor.
      *
      * @param string $type
-     * @param string|null $hydrateGroup
+     * @param string[]|null $hydrateGroups
      */
-    public function __construct(string $type, string $hydrateGroup = null) {
+    public function __construct(string $type, array $hydrateGroups = null) {
         $this->type = $type;
-        $this->hydrateGroup = $hydrateGroup;
+        $this->hydrateGroups = $hydrateGroups;
     }
 
     /**
@@ -47,13 +47,13 @@ class TestTypeGroupResolver extends AbstractDataResolver {
     }
 
     /**
-     * @return string
+     * @return array
      */
-    public function getHydrateGroup(): string {
-        if ($this->hydrateGroup === null) {
-            return parent::getHydrateGroup();
+    public function getHydrateGroups(): array {
+        if ($this->hydrateGroups === null) {
+            return parent::getHydrateGroups();
         } else {
-            return $this->hydrateGroup;
+            return $this->hydrateGroups;
         }
     }
 }

--- a/tests/Fixtures/schemaReference.json
+++ b/tests/Fixtures/schemaReference.json
@@ -1,0 +1,406 @@
+{
+    "$ref": "#\/$defs\/resolver",
+    "$schema": "http:\/\/json-schema.org\/draft-07\/schema",
+    "$defs": {
+        "resolver": {
+            "oneOf": [
+                {
+                    "$ref": "#\/$defs\/literal"
+                },
+                {
+                    "$ref": "#\/$defs\/param"
+                },
+                {
+                    "$ref": "#\/$defs\/ref"
+                },
+                {
+                    "$ref": "#\/$defs\/sprintf"
+                },
+                {
+                    "$ref": "#\/$defs\/assertEquals"
+                }
+            ],
+            "properties": {
+                "$hydrate": {
+                    "type": "string",
+                    "enum": [
+                        "literal",
+                        "param",
+                        "ref",
+                        "sprintf",
+                        "assertEquals"
+                    ]
+                }
+            },
+            "required": [
+                "$hydrate"
+            ]
+        },
+        "literal": {
+            "description": "A literal returns it's exact data value before any other processing.",
+            "type": "object",
+            "properties": {
+                "data": {
+                    "x-no-hydrate": true,
+                    "description": "The value of the literal",
+                    "type": [
+                        "array",
+                        "object",
+                        "string",
+                        "number",
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "$hydrate": {
+                    "type": "string",
+                    "enum": [
+                        "literal"
+                    ]
+                }
+            },
+            "required": [
+                "data",
+                "$hydrate"
+            ]
+        },
+        "param": {
+            "description": "Params are data passed in during hydration.",
+            "type": "object",
+            "properties": {
+                "ref": {
+                    "description": "The parameter name.",
+                    "type": "string",
+                    "x-no-hydrate": true
+                },
+                "default": {
+                    "oneOf": [
+                        {
+                            "type": [
+                                "array",
+                                "object",
+                                "string",
+                                "number",
+                                "boolean",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "description": "A default value for the parameter value. Defaults to null.",
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "$hydrate": {
+                    "type": "string",
+                    "enum": [
+                        "param"
+                    ]
+                }
+            },
+            "required": [
+                "ref",
+                "$hydrate"
+            ]
+        },
+        "ref": {
+            "type": "object",
+            "description": "Reference data from other parts of the hydration by it's path.",
+            "properties": {
+                "ref": {
+                    "description": "A local reference within the document. For example: \"\/path\/to\/property\/from\/root\".",
+                    "type": "string",
+                    "x-no-hydrate": true
+                },
+                "default": {
+                    "oneOf": [
+                        {
+                            "type": [
+                                "array",
+                                "object",
+                                "string",
+                                "number",
+                                "boolean",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "description": "Default value if the ref could not be resolved. Defaults to null.",
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "$hydrate": {
+                    "type": "string",
+                    "enum": [
+                        "ref"
+                    ]
+                }
+            },
+            "required": [
+                "ref",
+                "$hydrate"
+            ]
+        },
+        "sprintf": {
+            "type": "object",
+            "description": "Call sprintf($format, $args).",
+            "properties": {
+                "format": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "description": "The format string.",
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "args": {
+                    "oneOf": [
+                        {
+                            "type": "array"
+                        },
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "description": "Arguments to interpolate into the format string.",
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "$hydrate": {
+                    "type": "string",
+                    "enum": [
+                        "sprintf"
+                    ]
+                }
+            },
+            "required": [
+                "format",
+                "$hydrate"
+            ]
+        },
+        "assertEquals": {
+            "type": "object",
+            "description": "Call the function `PHPUnit\\Framework\\Assert::assertEquals(expected, actual, message, delta, maxDepth, canonicalize, ignoreCase)`",
+            "properties": {
+                "expected": {
+                    "oneOf": [
+                        [],
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "actual": {
+                    "oneOf": [
+                        [],
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "message": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "default": ""
+                        },
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "delta": {
+                    "oneOf": [
+                        {
+                            "type": "number",
+                            "default": 0
+                        },
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "maxDepth": {
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "default": 10
+                        },
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "canonicalize": {
+                    "oneOf": [
+                        {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "ignoreCase": {
+                    "oneOf": [
+                        {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ],
+                    "properties": {
+                        "$hydrate": {
+                            "type": "string",
+                            "enum": [
+                                "literal",
+                                "param",
+                                "ref",
+                                "sprintf",
+                                "assertEquals"
+                            ]
+                        }
+                    }
+                },
+                "$hydrate": {
+                    "type": "string",
+                    "enum": [
+                        "assertEquals"
+                    ]
+                }
+            },
+            "required": [
+                "expected",
+                "actual",
+                "$hydrate"
+            ]
+        }
+    }
+}

--- a/tests/Fixtures/schemaTests.json
+++ b/tests/Fixtures/schemaTests.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "./schemaReference.json",
+    "$hydrate": "",
+}

--- a/tests/Fixtures/schemaTests.json
+++ b/tests/Fixtures/schemaTests.json
@@ -1,4 +1,0 @@
-{
-    "$schema": "./schemaReference.json",
-    "$hydrate": "",
-}

--- a/tests/FunctionResolverTest.php
+++ b/tests/FunctionResolverTest.php
@@ -7,6 +7,7 @@
 
 namespace Garden\Hydrate\Tests;
 
+use Garden\Hydrate\DataHydrator;
 use Garden\Hydrate\Resolvers\FunctionResolver;
 use Garden\Schema\ValidationException;
 use PHPUnit\Framework\TestCase;
@@ -191,5 +192,22 @@ class FunctionResolverTest extends TestCase {
         $expected = new \ArrayObject(['foo' => 'bar']);
         $actual = $resolver->resolve(['a' => $expected], []);
         $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test type name generation.
+     */
+    public function testGetType() {
+        $resolver = new FunctionResolver([DataHydrator::class, 'makeResolver']);
+        $this->assertSame('makeResolver', $resolver->getType());
+
+        $resolver = new FunctionResolver([$this, 'testGetType']);
+        $this->assertSame('testGetType', $resolver->getType());
+
+        $resolver = new FunctionResolver([$this, 'testGetType'], 'customName');
+        $this->assertSame('customName', $resolver->getType());
+
+        $resolver = new FunctionResolver('sprintf');
+        $this->assertSame('sprintf', $resolver->getType());
     }
 }

--- a/tests/MutationsTest.php
+++ b/tests/MutationsTest.php
@@ -7,6 +7,7 @@
 namespace Garden\Hydrate\Tests;
 
 use Garden\Hydrate\DataHydrator;
+use Garden\Hydrate\Exception\InvalidHydrateSpecException;
 use Garden\Hydrate\Tests\Fixtures\ExceptionThrowerResolver;
 use Garden\Hydrate\Tests\Fixtures\TestExceptionHandler;
 use Garden\Hydrate\Tests\Fixtures\TestStringResolver;
@@ -27,8 +28,8 @@ class MutationsTest extends TestCase {
         $this->hydrator = new DataHydrator();
         $this->hydrator
             ->setExceptionHandler(new TestExceptionHandler())
-            ->addResolver('exception', new ExceptionThrowerResolver())
-            ->addResolver('str', new TestStringResolver('a'));
+            ->addResolver(new ExceptionThrowerResolver())
+            ->addResolver(new TestStringResolver('a'));
     }
 
     /**
@@ -36,8 +37,8 @@ class MutationsTest extends TestCase {
      */
     public function testStaticTypeField() {
         $spec = [DataHydrator::KEY_HYDRATE => [DataHydrator::KEY_HYDRATE => 'param', 'ref' => 'foo']];
-        $this->expectException(\Throwable::class);
-        $actual = $this->hydrator->hydrate($spec, ['foo' => 'literal']);
+        $this->expectException(InvalidHydrateSpecException::class);
+        $actual = $this->hydrator->resolve($spec, ['foo' => 'literal']);
     }
 
     /**

--- a/tests/Schema/HydrateableSchemaTest.php
+++ b/tests/Schema/HydrateableSchemaTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @author Adam Charron <adam@charrondev.com>
+ * @copyright 2009-2021 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Hydrate\Tests;
+
+use Garden\Hydrate\Schema\HydrateableSchema;
+use Garden\Schema\Schema;
+use PHPUnit\Framework\TestCase;
+
+class HydrateableSchemaTest extends TestCase {
+
+    public function testConvertObject() {
+        $in = Schema::parse([
+            'foo:s?',
+        ])->getSchemaArray();
+        $hydrateable = new HydrateableSchema($in, 'withFoo');
+
+        $expected = [
+            'type' => 'object',
+            'properties' => [
+                'foo' => [
+                    'oneOf' => [
+                        [
+                            'type' => 'string',
+                        ],
+                        [
+                            '$ref' => '#/$defs/resolver',
+                        ],
+                    ],
+                    'properties' => [
+                        '$hydrate' => [
+                            'type' => 'string',
+                            'enum' => [],
+                        ],
+                    ],
+                    'required' => [
+                        '$hydrate',
+                    ],
+                ],
+                '$hydrate' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'withFoo',
+                    ],
+                ],
+            ],
+            'required' => [
+                '$hydrate',
+            ],
+        ];
+        $this->assertSame($expected, $hydrateable->getSchemaArray());
+    }
+
+    public function testPrimitiveType() {
+        $in = Schema::parse([
+            'type' => ['number', 'string', 'null'],
+            'minLength' => 20,
+        ])->getSchemaArray();
+
+        $expected = [
+            'oneOf' => [
+                [
+                    'type' => ['number', 'string', 'null'],
+                    'minLength' => 20,
+                ],
+                [
+                    '$ref' => '#/$defs/resolver',
+                ],
+            ],
+            'properties' => [
+                '$hydrate' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'primitive',
+                    ],
+                ],
+            ],
+            'required' => [
+                '$hydrate',
+            ],
+        ];
+        $hydrateable = new HydrateableSchema($in, 'primitive');
+        $this->assertSame($expected, $hydrateable->getSchemaArray());
+    }
+
+    public function testExistingOneOf() {
+        $in = [
+            'oneOf' => [
+                [
+                    'type' => 'number'
+                ],
+                [
+                    'type' => 'string'
+                ]
+            ],
+        ];
+
+        $expected = [
+            'oneOf' => [
+                [
+                    'type' => 'number'
+                ],
+                [
+                    'type' => 'string'
+                ],
+                [
+                    '$ref' => '#/$defs/resolver',
+                ],
+            ],
+            'properties' => [
+                '$hydrate' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'primitive',
+                    ],
+                ],
+            ],
+            'required' => [
+                '$hydrate',
+            ],
+        ];
+        $hydrateable = new HydrateableSchema($in, 'primitive');
+        $this->assertSame($expected, $hydrateable->getSchemaArray());
+    }
+}

--- a/tests/Schema/HydrateableSchemaTest.php
+++ b/tests/Schema/HydrateableSchemaTest.php
@@ -23,10 +23,9 @@ class HydrateableSchemaTest extends TestCase {
      * Test addition of the hydrate property and unions to sub-properties.
      */
     public function testConvertObject() {
-        $in = Schema::parse([
+        $hydrateable = HydrateableSchema::parse([
             'foo:s?',
-        ])->getSchemaArray();
-        $hydrateable = new HydrateableSchema($in, 'withFoo');
+        ], 'withFoo')->getSchemaArray();
 
         $expected = [
             'type' => 'object',
@@ -58,7 +57,7 @@ class HydrateableSchemaTest extends TestCase {
                 '$hydrate',
             ],
         ];
-        $this->assertSame($expected, $hydrateable->getSchemaArray());
+        $this->assertSame($expected, $hydrateable);
     }
 
     /**
@@ -129,7 +128,7 @@ class HydrateableSchemaTest extends TestCase {
             ],
             'required' => ['foo'],
         ];
-        $hydrateable = (new HydrateableSchema($in, 'myType'))->getSchemaArray();
+        $hydrateable = HydrateableSchema::parse($in, 'myType')->getSchemaArray();
         $this->assertEquals(['foo', '$hydrate'], $hydrateable['required']);
     }
 
@@ -147,7 +146,7 @@ class HydrateableSchemaTest extends TestCase {
             ],
             'required' => ['foo'],
         ];
-        $hydrateable = (new HydrateableSchema($in, 'myType'))->getSchemaArray();
+        $hydrateable = HydrateableSchema::parse($in, 'myType')->getSchemaArray();
         $this->assertEquals($hydrateable['properties']['foo'], $in['properties']['foo']);
     }
 
@@ -159,7 +158,7 @@ class HydrateableSchemaTest extends TestCase {
             JsonSchemaGenerator::ROOT_HYDRATE_GROUP => ['one', 'two', 'three'],
             'subgroup' => ['one', 'two'],
         ];
-        $hydrateable = (new HydrateableSchema(Schema::parse([
+        $hydrateable = HydrateableSchema::parse([
             'any' => [
                 'type' => 'string',
             ],
@@ -167,7 +166,7 @@ class HydrateableSchemaTest extends TestCase {
                 'type' => 'string',
                 HydrateableSchema::X_HYDRATE_GROUP => 'subgroup',
             ],
-        ]), 'inType', $groups))->getSchemaArray();
+        ], 'inType', $groups)->getSchemaArray();
 
         $this->assertSame(
             $groups[JsonSchemaGenerator::ROOT_HYDRATE_GROUP],

--- a/tests/Schema/JsonSchemaGeneratorTest.php
+++ b/tests/Schema/JsonSchemaGeneratorTest.php
@@ -50,8 +50,8 @@ class JsonSchemaGeneratorTest extends TestCase {
     public function testHydrateGroups() {
         $hydrator = new DataHydrator();
         $hydrator->addResolver(new TestTypeGroupResolver('rootHydrate'));
-        $hydrator->addResolver(new TestTypeGroupResolver('customHydrate1', 'custom1'));
-        $hydrator->addResolver(new TestTypeGroupResolver('customHydrate2', 'custom2'));
+        $hydrator->addResolver(new TestTypeGroupResolver('customHydrate1', ['custom1']));
+        $hydrator->addResolver(new TestTypeGroupResolver('customHydrate1And2', ['custom1', 'custom2']));
 
         $schemaGenerator = $hydrator->getSchemaGenerator();
         $this->assertSame([
@@ -62,10 +62,10 @@ class JsonSchemaGeneratorTest extends TestCase {
                 'sprintf',
                 'rootHydrate',
                 'customHydrate1',
-                'customHydrate2',
+                'customHydrate1And2',
             ],
-            'custom1' => ['customHydrate1'],
-            'custom2' => ['customHydrate2'],
+            'custom1' => ['customHydrate1', 'customHydrate1And2'],
+            'custom2' => ['customHydrate1And2'],
         ], $schemaGenerator->getTypesByGroup());
     }
 }

--- a/tests/Schema/JsonSchemaGeneratorTest.php
+++ b/tests/Schema/JsonSchemaGeneratorTest.php
@@ -8,20 +8,33 @@
 namespace Garden\Hydrate\Tests;
 
 use Garden\Hydrate\DataHydrator;
-use Garden\Hydrate\Tests\Fixtures\TestStringResolver;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests for the schema generator.
+ */
 class JsonSchemaGeneratorTest extends TestCase {
 
-    public function testGenerateSchema() {
-        $out = __DIR__ . '/../Fixtures/schemaReference.json';
+    /**
+     * Since \Garden\Schema can't currently validate with oneOf (until version 2 or 3) we just do a snapshot test.
+     */
+    public function testCompareSnapshot() {
+        $testRoot = realpath(__DIR__ . '/..');
+        $cacheDir = $testRoot . '/Fixtures';
+        if (!file_exists($cacheDir)) {
+            mkdir($cacheDir, 0777, true);
+        }
+        $referencePath = $cacheDir . '/schemaReference.json';
         $hydrator = new DataHydrator();
-        $hydrator->addResolver(new TestStringResolver("testString"));
         $generator = $hydrator->getSchemaGenerator();
         $schema = $generator->getDefaultSchema();
-        $json = json_encode($schema, JSON_PRETTY_PRINT);
-        file_put_contents($out, $json);
-        $this->assertEquals(true, true);
+
+        $actual = json_encode($schema, JSON_PRETTY_PRINT);
+        // Uncomment this to generate a new file.
+//        file_put_contents($referencePath, $actual);
+
+        $expected = file_get_contents($referencePath);
+        $this->assertEquals($expected, $actual);
     }
 
 }

--- a/tests/Schema/JsonSchemaGeneratorTest.php
+++ b/tests/Schema/JsonSchemaGeneratorTest.php
@@ -8,6 +8,7 @@
 namespace Garden\Hydrate\Tests;
 
 use Garden\Hydrate\DataHydrator;
+use Garden\Hydrate\Resolvers\FunctionResolver;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -26,12 +27,15 @@ class JsonSchemaGeneratorTest extends TestCase {
         }
         $referencePath = $cacheDir . '/schemaReference.json';
         $hydrator = new DataHydrator();
+        $hydrator->addResolver(
+            new FunctionResolver([TestCase::class, 'assertEquals'])
+        );
         $generator = $hydrator->getSchemaGenerator();
         $schema = $generator->getDefaultSchema();
 
         $actual = json_encode($schema, JSON_PRETTY_PRINT);
         // Uncomment this to generate a new file.
-//        file_put_contents($referencePath, $actual);
+        // file_put_contents($referencePath, $actual);
 
         $expected = file_get_contents($referencePath);
         $this->assertEquals($expected, $actual);

--- a/tests/Schema/JsonSchemaGeneratorTest.php
+++ b/tests/Schema/JsonSchemaGeneratorTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Adam Charron <adam@charrondev.com>
+ * @copyright 2009-2021 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Hydrate\Tests;
+
+use Garden\Hydrate\DataHydrator;
+use Garden\Hydrate\Tests\Fixtures\TestStringResolver;
+use PHPUnit\Framework\TestCase;
+
+class JsonSchemaGeneratorTest extends TestCase {
+
+    public function testGenerateSchema() {
+        $out = __DIR__ . '/../Fixtures/schemaReference.json';
+        $hydrator = new DataHydrator();
+        $hydrator->addResolver(new TestStringResolver("testString"));
+        $generator = $hydrator->getSchemaGenerator();
+        $schema = $generator->getDefaultSchema();
+        $json = json_encode($schema, JSON_PRETTY_PRINT);
+        file_put_contents($out, $json);
+        $this->assertEquals(true, true);
+    }
+
+}

--- a/tests/Schema/JsonSchemaGeneratorTest.php
+++ b/tests/Schema/JsonSchemaGeneratorTest.php
@@ -9,6 +9,9 @@ namespace Garden\Hydrate\Tests;
 
 use Garden\Hydrate\DataHydrator;
 use Garden\Hydrate\Resolvers\FunctionResolver;
+use Garden\Hydrate\Schema\JsonSchemaGenerator;
+use Garden\Hydrate\Tests\Fixtures\TestStringResolver;
+use Garden\Hydrate\Tests\Fixtures\TestTypeGroupResolver;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -41,4 +44,28 @@ class JsonSchemaGeneratorTest extends TestCase {
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * Test that hydrators are put in the correct groups.
+     */
+    public function testHydrateGroups() {
+        $hydrator = new DataHydrator();
+        $hydrator->addResolver(new TestTypeGroupResolver('rootHydrate'));
+        $hydrator->addResolver(new TestTypeGroupResolver('customHydrate1', 'custom1'));
+        $hydrator->addResolver(new TestTypeGroupResolver('customHydrate2', 'custom2'));
+
+        $schemaGenerator = $hydrator->getSchemaGenerator();
+        $this->assertSame([
+            JsonSchemaGenerator::ROOT_HYDRATE_GROUP => [
+                'literal',
+                'param',
+                'ref',
+                'sprintf',
+                'rootHydrate',
+                'customHydrate1',
+                'customHydrate2',
+            ],
+            'custom1' => ['customHydrate1'],
+            'custom2' => ['customHydrate2'],
+        ], $schemaGenerator->getTypesByGroup());
+    }
 }


### PR DESCRIPTION
## Changes

- Types are now declared on there resolver **_Breaking change_**
- Add ability to generate schemas from data resolvers.
- `HydrateableSchema` is a Schema subclass that does the following:
  - Ensures a `$hydrate` parameter is present.
  - Makes all sub-properties a union with other hydrate schemas.
  - A property can be opted out of allowing hydration by using the `x-no-hydrate: true` flag.
  - A property can restrict it's allowable hydrate type by setting `x-hydate-group: GROUP_NAME`.
- Resolvers can now declare hydrate groups that they belong to. All resolvers always belong to the root group, but can belong to additional groups as well.

## Schema in action

<img width="1158" alt="image" src="https://user-images.githubusercontent.com/1770056/127899322-a34ec6f6-40a3-4ca4-9c96-742d5e0cf98f.png">

## Chores

- Extend .gitignore
- Add ext-json to composer.
- Fix example in README
- Add descriptions for all schema properties.