### PR TITLE
Fix garden-schema version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "ext-json": "*",
         "vanilla/garden-jsont": "^1.2",
-        "vanilla/garden-schema": "~1.10.2"
+        "vanilla/garden-schema": "^1.10.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fix the garden schema version. It was too strict. We want to allow anything under any 1.x release, which means we should use the `^` which allows non-breaking changes.