### PR TITLE
Fix schema generation in garden-hydrate

### DIFF
--- a/src/Resolvers/FunctionResolver.php
+++ b/src/Resolvers/FunctionResolver.php
@@ -109,6 +109,11 @@ class FunctionResolver extends AbstractDataResolver {
                 }
             }
 
+            // Fallback so we don't end up with an empty schema array.
+            if (!isset($schema['type'])) {
+                $schema['type'] = ['boolean', 'string', 'number', 'array', 'object'];
+            }
+
             $properties[$param->getName()] = $schema;
         }
         $propertiesName = implode(", ", array_keys($properties));

--- a/src/Resolvers/ParamResolver.php
+++ b/src/Resolvers/ParamResolver.php
@@ -8,7 +8,6 @@
 namespace Garden\Hydrate\Resolvers;
 
 use Garden\Hydrate\Schema\HydrateableSchema;
-use Garden\Hydrate\Schema\JsonSchemaGenerator;
 use Garden\JSON\ReferenceResolverTrait;
 use Garden\Schema\Schema;
 

--- a/src/Schema/HydrateableSchema.php
+++ b/src/Schema/HydrateableSchema.php
@@ -170,6 +170,7 @@ class HydrateableSchema extends Schema {
         // Clear the description, we're hoisting it.
         $hydrateGroup = $schemaArray[self::X_HYDRATE_GROUP] ?? JsonSchemaGenerator::ROOT_HYDRATE_GROUP;
         $description = $schemaArray['description'] ?? null;
+        unset($schemaArray['description']);
         $schemaArray = [
             'oneOf' => [
                 $schemaArray,

--- a/src/Schema/HydrateableSchema.php
+++ b/src/Schema/HydrateableSchema.php
@@ -69,6 +69,9 @@ class HydrateableSchema extends Schema {
             throw new InvalidHydrateSpecException($message);
         }
 
+        // Make sure we are an object.
+        $schemaArray['type'] = 'object';
+
         // Make sure hydrate key is required.
         $schemaArray['properties'] = $schemaArray['properties'] ?? [];
         $schemaArray['properties'][DataHydrator::KEY_HYDRATE] = [

--- a/src/Schema/HydrateableSchema.php
+++ b/src/Schema/HydrateableSchema.php
@@ -97,6 +97,7 @@ class HydrateableSchema extends Schema {
      * Allow hydrate in a schema.
      *
      * @param array $schemaArray
+     * @param bool $isTopLevel Set to true to indicate that we are the top level definition of the schema and not a property.
      *
      * @return array
      */

--- a/src/Schema/JsonSchemaGenerator.php
+++ b/src/Schema/JsonSchemaGenerator.php
@@ -88,6 +88,18 @@ class JsonSchemaGenerator {
      */
     public function getDefaultSchema(): Schema {
         $schema = new Schema(self::getDefReference());
+        $schema = $this->decorateSchema($schema);
+        return $schema;
+    }
+
+    /**
+     * Decorate an existing schema with the definitions of the hydration.
+     *
+     * @param Schema $schema The schema to decorate.
+     *
+     * @return Schema
+     */
+    public function decorateSchema(Schema $schema): Schema {
         $schema->setField('$schema', self::SCHEMA_DRAFT_7_URL);
         $schema->setField('$defs', $this->createCombinedDefsArray());
         return $schema;

--- a/src/Schema/JsonSchemaGenerator.php
+++ b/src/Schema/JsonSchemaGenerator.php
@@ -156,7 +156,7 @@ class JsonSchemaGenerator {
         $type = $resolver->getType();
         $schema = $resolver->getSchema();
         $schemaArray = $schema ? $schema->getSchemaArray() : HydrateableSchema::ANY_OBJECT_SCHEMA_ARRAY;
-        $hydrateableSchema = new HydrateableSchema($schemaArray, $type, $this->typesByGroup);
+        $hydrateableSchema = new HydrateableSchema($schemaArray, $type);
         $this->referencesByType[$type] = $hydrateableSchema->getSchemaArray();
     }
 

--- a/src/Schema/JsonSchemaGenerator.php
+++ b/src/Schema/JsonSchemaGenerator.php
@@ -21,11 +21,6 @@ class JsonSchemaGenerator {
     /** @var string The definition key used for the combined resolver types. */
     public const ROOT_HYDRATE_GROUP = 'resolver';
 
-    /** @var string[] A reference to all resolver types. */
-    public const ROOT_HYDRATE_REF = [
-        '$ref' => '#/$defs/' . self::ROOT_HYDRATE_GROUP
-    ];
-
     /** @var AbstractDataResolver[] */
     private $resolvers;
 
@@ -92,7 +87,7 @@ class JsonSchemaGenerator {
      * @return Schema
      */
     public function getDefaultSchema(): Schema {
-        $schema = new Schema(self::ROOT_HYDRATE_REF);
+        $schema = new Schema(self::getDefReference());
         $schema->setField('$schema', self::SCHEMA_DRAFT_7_URL);
         $schema->setField('$defs', $this->createCombinedDefsArray());
         return $schema;
@@ -112,7 +107,7 @@ class JsonSchemaGenerator {
                 'properties' => [
                     DataHydrator::KEY_HYDRATE => [
                         'type' => 'string',
-                        'enum' => $this->allTypes,
+                        'enum' => $types,
                     ]
                 ],
                 'required' => [DataHydrator::KEY_HYDRATE]
@@ -133,7 +128,7 @@ class JsonSchemaGenerator {
      *
      * @return array The reference.
      */
-    private static function getDefReference(string $defKey): array {
+    public static function getDefReference(string $defKey = self::ROOT_HYDRATE_GROUP): array {
         return [
             '$ref' => '#/$defs/' . $defKey,
         ];

--- a/tests/Fixtures/NestedObjSchemaResolver.php
+++ b/tests/Fixtures/NestedObjSchemaResolver.php
@@ -5,17 +5,9 @@
  * @license MIT
  */
 
-
-/**
- * @author Todd Burry <todd@vanillaforums.com>
- * @copyright 2009-2020 Vanilla Forums Inc.
- * @license MIT
- */
-
 namespace Garden\Hydrate\Tests\Fixtures;
 
 use Garden\Hydrate\Resolvers\AbstractDataResolver;
-use Garden\Hydrate\DataHydrator;
 use Garden\Schema\Schema;
 
 /**

--- a/tests/Fixtures/NestedObjSchemaResolver.php
+++ b/tests/Fixtures/NestedObjSchemaResolver.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @author Adam Charron <adam@charrondev.com>
+ * @copyright 2009-2021 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Hydrate\Tests\Fixtures;
+
+use Garden\Hydrate\Resolvers\AbstractDataResolver;
+use Garden\Hydrate\DataHydrator;
+use Garden\Schema\Schema;
+
+/**
+ * A resolver with a nested object schema.
+ */
+class NestedObjSchemaResolver extends AbstractDataResolver {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function resolveInternal(array $data, array $params = []) {
+        return 'nestedObj';
+    }
+
+    /**
+     * @return Schema|null
+     */
+    public function getSchema(): ?Schema {
+        return Schema::parse([
+            'nested' => [
+                'type' => 'object',
+                'properties' => [
+                    'foo' => [
+                        'type' => 'string'
+                    ],
+                    'bar' => [
+                        'type' => 'string'
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string {
+        return 'nestedObjSchema';
+    }
+}

--- a/tests/Fixtures/schemaReference.json
+++ b/tests/Fixtures/schemaReference.json
@@ -80,7 +80,6 @@
                 "default": {
                     "oneOf": [
                         {
-                            "description": "A default value for the parameter value. Defaults to null.",
                             "type": [
                                 "array",
                                 "object",
@@ -121,7 +120,6 @@
                 "default": {
                     "oneOf": [
                         {
-                            "description": "Default value if the ref could not be resolved. Defaults to null.",
                             "type": [
                                 "array",
                                 "object",
@@ -157,7 +155,6 @@
                 "format": {
                     "oneOf": [
                         {
-                            "description": "The format string.",
                             "type": "string"
                         },
                         {
@@ -169,7 +166,6 @@
                 "args": {
                     "oneOf": [
                         {
-                            "description": "Arguments to interpolate into the format string.",
                             "type": "array"
                         },
                         {

--- a/tests/Fixtures/schemaReference.json
+++ b/tests/Fixtures/schemaReference.json
@@ -18,6 +18,9 @@
                 },
                 {
                     "$ref": "#\/$defs\/assertEquals"
+                },
+                {
+                    "$ref": "#\/$defs\/nestedObjSchema"
                 }
             ],
             "properties": {
@@ -28,7 +31,8 @@
                         "param",
                         "ref",
                         "sprintf",
-                        "assertEquals"
+                        "assertEquals",
+                        "nestedObjSchema"
                     ]
                 }
             },
@@ -76,6 +80,7 @@
                 "default": {
                     "oneOf": [
                         {
+                            "description": "A default value for the parameter value. Defaults to null.",
                             "type": [
                                 "array",
                                 "object",
@@ -90,19 +95,7 @@
                             "$ref": "#\/$defs\/resolver"
                         }
                     ],
-                    "description": "A default value for the parameter value. Defaults to null.",
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    "description": "A default value for the parameter value. Defaults to null."
                 },
                 "$hydrate": {
                     "type": "string",
@@ -128,6 +121,7 @@
                 "default": {
                     "oneOf": [
                         {
+                            "description": "Default value if the ref could not be resolved. Defaults to null.",
                             "type": [
                                 "array",
                                 "object",
@@ -142,19 +136,7 @@
                             "$ref": "#\/$defs\/resolver"
                         }
                     ],
-                    "description": "Default value if the ref could not be resolved. Defaults to null.",
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    "description": "Default value if the ref could not be resolved. Defaults to null."
                 },
                 "$hydrate": {
                     "type": "string",
@@ -175,48 +157,26 @@
                 "format": {
                     "oneOf": [
                         {
+                            "description": "The format string.",
                             "type": "string"
                         },
                         {
                             "$ref": "#\/$defs\/resolver"
                         }
                     ],
-                    "description": "The format string.",
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    "description": "The format string."
                 },
                 "args": {
                     "oneOf": [
                         {
+                            "description": "Arguments to interpolate into the format string.",
                             "type": "array"
                         },
                         {
                             "$ref": "#\/$defs\/resolver"
                         }
                     ],
-                    "description": "Arguments to interpolate into the format string.",
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    "description": "Arguments to interpolate into the format string."
                 },
                 "$hydrate": {
                     "type": "string",
@@ -236,43 +196,35 @@
             "properties": {
                 "expected": {
                     "oneOf": [
-                        [],
+                        {
+                            "type": [
+                                "boolean",
+                                "string",
+                                "number",
+                                "array",
+                                "object"
+                            ]
+                        },
                         {
                             "$ref": "#\/$defs\/resolver"
                         }
-                    ],
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    ]
                 },
                 "actual": {
                     "oneOf": [
-                        [],
+                        {
+                            "type": [
+                                "boolean",
+                                "string",
+                                "number",
+                                "array",
+                                "object"
+                            ]
+                        },
                         {
                             "$ref": "#\/$defs\/resolver"
                         }
-                    ],
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    ]
                 },
                 "message": {
                     "oneOf": [
@@ -283,19 +235,7 @@
                         {
                             "$ref": "#\/$defs\/resolver"
                         }
-                    ],
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    ]
                 },
                 "delta": {
                     "oneOf": [
@@ -306,19 +246,7 @@
                         {
                             "$ref": "#\/$defs\/resolver"
                         }
-                    ],
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    ]
                 },
                 "maxDepth": {
                     "oneOf": [
@@ -329,19 +257,7 @@
                         {
                             "$ref": "#\/$defs\/resolver"
                         }
-                    ],
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    ]
                 },
                 "canonicalize": {
                     "oneOf": [
@@ -352,19 +268,7 @@
                         {
                             "$ref": "#\/$defs\/resolver"
                         }
-                    ],
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    ]
                 },
                 "ignoreCase": {
                     "oneOf": [
@@ -375,19 +279,7 @@
                         {
                             "$ref": "#\/$defs\/resolver"
                         }
-                    ],
-                    "properties": {
-                        "$hydrate": {
-                            "type": "string",
-                            "enum": [
-                                "literal",
-                                "param",
-                                "ref",
-                                "sprintf",
-                                "assertEquals"
-                            ]
-                        }
-                    }
+                    ]
                 },
                 "$hydrate": {
                     "type": "string",
@@ -399,6 +291,58 @@
             "required": [
                 "expected",
                 "actual",
+                "$hydrate"
+            ]
+        },
+        "nestedObjSchema": {
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "foo": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "$ref": "#\/$defs\/resolver"
+                                        }
+                                    ]
+                                },
+                                "bar": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "$ref": "#\/$defs\/resolver"
+                                        }
+                                    ]
+                                }
+                            },
+                            "not": {
+                                "required": [
+                                    "$hydrate"
+                                ]
+                            }
+                        },
+                        {
+                            "$ref": "#\/$defs\/resolver"
+                        }
+                    ]
+                },
+                "$hydrate": {
+                    "type": "string",
+                    "enum": [
+                        "nestedObjSchema"
+                    ]
+                }
+            },
+            "required": [
+                "nested",
                 "$hydrate"
             ]
         }

--- a/tests/FunctionResolverTest.php
+++ b/tests/FunctionResolverTest.php
@@ -189,8 +189,9 @@ class FunctionResolverTest extends TestCase {
         $actual = $resolver->resolve(['a' => 'foo'], []);
         $this->assertSame('foo', $actual);
 
-        $expected = new \ArrayObject(['foo' => 'bar']);
-        $actual = $resolver->resolve(['a' => $expected], []);
+        $input = new \ArrayObject(['foo' => 'bar']);
+        $actual = $resolver->resolve(['a' => $input], []);
+        $expected = ['foo' => 'bar'];
         $this->assertSame($expected, $actual);
     }
 

--- a/tests/Schema/HydrateableSchemaTest.php
+++ b/tests/Schema/HydrateableSchemaTest.php
@@ -76,20 +76,20 @@ class HydrateableSchemaTest extends TestCase {
                     'type' => 'object',
                     'properties' => [
                         'num' => [
-                            'type' => 'number'
+                            'type' => 'number',
                         ],
-                        'required' => ['num']
-                    ]
+                        'required' => ['num'],
+                    ],
                 ],
                 [
                     'type' => 'object',
                     'properties' => [
                         'str' => [
-                            'type' => 'string'
+                            'type' => 'string',
                         ],
-                        'required' => ['str']
-                    ]
-                ]
+                        'required' => ['str'],
+                    ],
+                ],
             ],
         ];
 
@@ -99,19 +99,19 @@ class HydrateableSchemaTest extends TestCase {
                     'type' => 'object',
                     'properties' => [
                         'num' => [
-                            'type' => 'number'
+                            'type' => 'number',
                         ],
-                        'required' => ['num']
-                    ]
+                        'required' => ['num'],
+                    ],
                 ],
                 [
                     'type' => 'object',
                     'properties' => [
                         'str' => [
-                            'type' => 'string'
+                            'type' => 'string',
                         ],
-                        'required' => ['str']
-                    ]
+                        'required' => ['str'],
+                    ],
                 ],
                 [
                     '$ref' => '#/$defs/resolver',
@@ -196,5 +196,55 @@ class HydrateableSchemaTest extends TestCase {
             ['$ref' => '#/$defs/subgroup'],
             $hydrateable['properties']['limited']['oneOf'][1]
         );
+    }
+
+    /**
+     * Test hydration of list items.
+     */
+    public function testHydrateItems() {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'childList' => [
+                    HydrateableSchema::X_NO_HYDRATE => true,
+                    HydrateableSchema::X_FORCE_HYDRATE_ITEMS => true,
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+        ];
+        $hydrateable = (new HydrateableSchema($schema, 'myType'))->getSchemaArray();
+
+        $this->assertSame([
+            'type' => 'object',
+            'properties' => [
+                'childList' => [
+                    'x-no-hydrate' => true,
+                    'x-force-hydrate-items' => true,
+                    'type' => 'array',
+
+                    // Items were are hydrateable but not the childList itself.
+                    'items' => [
+                        'oneOf' => [
+                            [
+                                'type' => 'string',
+                            ],
+                            [
+                                '$ref' => '#/$defs/resolver',
+                            ],
+                        ],
+                    ],
+                ],
+                '$hydrate' => [
+                    'type' => 'string',
+                    'enum' => ['myType'],
+                ],
+            ],
+            'required' => [
+                '$hydrate',
+            ]
+        ], $hydrateable);
     }
 }

--- a/tests/Schema/HydrateableSchemaTest.php
+++ b/tests/Schema/HydrateableSchemaTest.php
@@ -73,10 +73,22 @@ class HydrateableSchemaTest extends TestCase {
         $in = [
             'oneOf' => [
                 [
-                    'type' => 'number'
+                    'type' => 'object',
+                    'properties' => [
+                        'num' => [
+                            'type' => 'number'
+                        ],
+                        'required' => ['num']
+                    ]
                 ],
                 [
-                    'type' => 'string'
+                    'type' => 'object',
+                    'properties' => [
+                        'str' => [
+                            'type' => 'string'
+                        ],
+                        'required' => ['str']
+                    ]
                 ]
             ],
         ];
@@ -84,15 +96,28 @@ class HydrateableSchemaTest extends TestCase {
         $expected = [
             'oneOf' => [
                 [
-                    'type' => 'number'
+                    'type' => 'object',
+                    'properties' => [
+                        'num' => [
+                            'type' => 'number'
+                        ],
+                        'required' => ['num']
+                    ]
                 ],
                 [
-                    'type' => 'string'
+                    'type' => 'object',
+                    'properties' => [
+                        'str' => [
+                            'type' => 'string'
+                        ],
+                        'required' => ['str']
+                    ]
                 ],
                 [
                     '$ref' => '#/$defs/resolver',
                 ],
             ],
+            'type' => 'object',
             'properties' => [
                 '$hydrate' => [
                     'type' => 'string',

--- a/tests/Schema/HydrateableSchemaTest.php
+++ b/tests/Schema/HydrateableSchemaTest.php
@@ -5,7 +5,7 @@
  * @license MIT
  */
 
-namespace Garden\Hydrate\Tests;
+namespace Garden\Hydrate\Tests\Schema;
 
 use Garden\Hydrate\DataHydrator;
 use Garden\Hydrate\Exception\InvalidHydrateSpecException;
@@ -39,12 +39,6 @@ class HydrateableSchemaTest extends TestCase {
                             '$ref' => '#/$defs/resolver',
                         ],
                     ],
-                    'properties' => [
-                        '$hydrate' => [
-                            'type' => 'string',
-                            // No enum here because we didn't give a type/group mapping.
-                        ],
-                    ],
                 ],
                 '$hydrate' => [
                     'type' => 'string',
@@ -61,7 +55,7 @@ class HydrateableSchemaTest extends TestCase {
     }
 
     /**
-     * Root level primitive types are not allowed (because all root types need to have a $hydrate parameter.
+     * Root level primitive types are not allowed (because all root types need to have a $hydrate parameter).
      */
     public function testPrimitiveTypeException() {
         $in = [
@@ -169,12 +163,13 @@ class HydrateableSchemaTest extends TestCase {
         ], 'inType', $groups)->getSchemaArray();
 
         $this->assertSame(
-            $groups[JsonSchemaGenerator::ROOT_HYDRATE_GROUP],
-            $hydrateable['properties']['any']['properties'][DataHydrator::KEY_HYDRATE]['enum']
+            ['$ref' => '#/$defs/' . JsonSchemaGenerator::ROOT_HYDRATE_GROUP],
+            $hydrateable['properties']['any']['oneOf'][1]
         );
+
         $this->assertSame(
-            $groups['subgroup'],
-            $hydrateable['properties']['limited']['properties'][DataHydrator::KEY_HYDRATE]['enum']
+            ['$ref' => '#/$defs/subgroup'],
+            $hydrateable['properties']['limited']['oneOf'][1]
         );
     }
 }

--- a/tests/Schema/JsonSchemaGeneratorTest.php
+++ b/tests/Schema/JsonSchemaGeneratorTest.php
@@ -5,11 +5,12 @@
  * @license MIT
  */
 
-namespace Garden\Hydrate\Tests;
+namespace Garden\Hydrate\Tests\Schema;
 
 use Garden\Hydrate\DataHydrator;
 use Garden\Hydrate\Resolvers\FunctionResolver;
 use Garden\Hydrate\Schema\JsonSchemaGenerator;
+use Garden\Hydrate\Tests\Fixtures\NestedObjSchemaResolver;
 use Garden\Hydrate\Tests\Fixtures\TestStringResolver;
 use Garden\Hydrate\Tests\Fixtures\TestTypeGroupResolver;
 use PHPUnit\Framework\TestCase;
@@ -33,6 +34,7 @@ class JsonSchemaGeneratorTest extends TestCase {
         $hydrator->addResolver(
             new FunctionResolver([TestCase::class, 'assertEquals'])
         );
+        $hydrator->addResolver(new NestedObjSchemaResolver());
         $generator = $hydrator->getSchemaGenerator();
         $schema = $generator->getDefaultSchema();
 


### PR DESCRIPTION
As I was moving towards implementation I found the need to resolve a few issues in the recent hydrateable schema I implemented.

- Properties with their definition as a `Garden\Schema` instance now work inside of `HydrateableSchema`.
- Adjust the outputted schema definitions:
  - The workaround to declare the hydrate enum on generated `oneOf` definitions is not longer required to make autocomplete work. Instead when we use `oneOf` with an object and the a resolver we apply a `not` definition to the original object schema to disallow `hydrate`.
- Fix the function resolver to prevent it from outputting empty schema arrays for properties without types.