### PR TITLE
Fix resolver not validating if the schema came from a getSchema override

### DIFF
--- a/src/Resolvers/AbstractDataResolver.php
+++ b/src/Resolvers/AbstractDataResolver.php
@@ -23,8 +23,9 @@ abstract class AbstractDataResolver implements ValidatableResolverInterface {
      * {@inheritDoc}
      */
     public function validate(array $data): array {
-        if ($this->schema !== null) {
-            return $this->schema->validate($data);
+        $schema = $this->getSchema();
+        if ($schema !== null) {
+            return $schema->validate($data);
         } else {
             return $data;
         }

--- a/tests/Fixtures/NestedObjSchemaResolver.php
+++ b/tests/Fixtures/NestedObjSchemaResolver.php
@@ -19,7 +19,7 @@ class NestedObjSchemaResolver extends AbstractDataResolver {
      * {@inheritDoc}
      */
     protected function resolveInternal(array $data, array $params = []) {
-        return 'nestedObj';
+        return $data;
     }
 
     /**


### PR DESCRIPTION
We had a bug in the `AbstractDataResolver` where it wouldn't properly apply a schema if it was defined in a `getSchema()` override instead of the constructor.