### PR TITLE
Cache resolved nodes when require hydration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "ext-json": "*",
         "vanilla/garden-jsont": "^1.2",
-        "vanilla/garden-schema": "^1.10.2"
+        "vanilla/garden-schema": "^1.10.2",
+        "symfony/cache": "^4.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -220,7 +220,7 @@ class DataHydrator {
     /**
      * Return the current cache item
      *
-     * @param string key
+     * @param string $key The cache key for the node
      * @return CacheItem
      */
     public function getCache($key = null) {
@@ -248,10 +248,8 @@ class DataHydrator {
 
     /**
      * Empty the cache of hydrated nodes and nodes hydrated count (for tests)
-     *
-     * @return void
      */
-    public function clearResolverCache(): void {
+    public function clearResolverCache() {
         $this->cache->clear();
     }
 

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -65,8 +65,6 @@ class DataHydrator {
     /** @var ArrayAdapter */
     private $cache;
 
-    /** @var int When running tests track resolved vs found in cache */
-    public $resolveCount = 0;
 
     /**
      * DataHydrator constructor.
@@ -205,9 +203,6 @@ class DataHydrator {
                 $data = $resolver->resolve($data, $params);
                 $cacheData->set($data);
                 $this->cache->save($cacheData);
-                if (defined('TESTMODE_ENABLED')) {
-                    $this->resolveCount++;
-                }
             } else {
                 $data = $cacheHit;
             }

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -21,7 +21,6 @@ use Garden\Hydrate\Schema\JsonSchemaGenerator;
 use Garden\Schema\Schema;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\CacheItem;
-use Symfony\Contracts\Cache\CacheInterface;
 
 /**
  * Allows data to by hydrated based on a spec that can include data resolvers or literal data.
@@ -63,7 +62,7 @@ class DataHydrator {
     /** @var array */
     private $layoutCacheNode;
 
-    /** @var CacheInterface */
+    /** @var CacheItem */
     private $cache;
 
     /** @var int When running tests track resolved vs found in cache */

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -218,14 +218,19 @@ class DataHydrator {
     }
 
     /**
-     * @inheritDoc
+     * Return the current cache item
+     *
+     * @param string key
+     * @return CacheItem
      */
     public function getCache($key = null) {
         return $this->cache->getItem($key);
     }
 
     /**
-     * @inheritDoc
+     * Create cache instance
+     *
+     * @return ArrayAdapter
      */
     private function createCache() {
         return new ArrayAdapter();

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -20,6 +20,8 @@ use Garden\Hydrate\Resolvers\SprintfResolver;
 use Garden\Hydrate\Schema\JsonSchemaGenerator;
 use Garden\Schema\Schema;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Contracts\Cache\CacheInterface;
 
 /**
  * Allows data to by hydrated based on a spec that can include data resolvers or literal data.
@@ -65,7 +67,7 @@ class DataHydrator {
     private $cache;
 
     /** @var int When running tests track resolved vs found in cache */
-    public $nodeResolved;
+    public $resolveCount;
 
     /**
      * DataHydrator constructor.
@@ -205,7 +207,7 @@ class DataHydrator {
                 $cacheData->set($data);
                 $this->cache->save($cacheData);
                 if (defined('TESTMODE_ENABLED')) {
-                    $this->nodeResolved++;
+                    $this->resolveCount++;
                 }
             } else {
                 $data = $cacheHit;
@@ -234,16 +236,6 @@ class DataHydrator {
      */
     private function createCache() {
         return new ArrayAdapter();
-    }
-
-    /**
-     * Get the current resolve run (nodes hydrated not cached) count
-     * Used to determine whether hydrate data found in cache in tests
-     *
-     * @return int
-     */
-    public function getResolveCount(): int {
-        return $this->resolveCount;
     }
 
     /**

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -57,6 +57,9 @@ class DataHydrator {
     /** @var LiteralResolver */
     private $literalResolver;
 
+    /** @var array */
+    private $layoutCacheNode;
+
     /** @var integer */
     private $resolveCount = 0;
 

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -62,7 +62,7 @@ class DataHydrator {
     /** @var array */
     private $layoutCacheNode;
 
-    /** @var CacheItem */
+    /** @var ArrayAdapter */
     private $cache;
 
     /** @var int When running tests track resolved vs found in cache */

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -66,7 +66,7 @@ class DataHydrator {
     private $cache;
 
     /** @var int When running tests track resolved vs found in cache */
-    public $resolveCount;
+    public $resolveCount = 0;
 
     /**
      * DataHydrator constructor.

--- a/src/DataHydrator.php
+++ b/src/DataHydrator.php
@@ -224,7 +224,7 @@ class DataHydrator {
      * @param string $key The cache key for the node
      * @return CacheItem
      */
-    public function getCache($key = null) {
+    public function getCache($key) {
         return $this->cache->getItem($key);
     }
 

--- a/src/Resolvers/AbstractDataResolver.php
+++ b/src/Resolvers/AbstractDataResolver.php
@@ -19,9 +19,6 @@ abstract class AbstractDataResolver implements ValidatableResolverInterface {
      */
     protected $schema;
 
-    /** @var array */
-    protected $layoutCacheNode;
-
     /**
      * {@inheritDoc}
      */
@@ -38,34 +35,10 @@ abstract class AbstractDataResolver implements ValidatableResolverInterface {
      * {@inheritDoc}
      */
     final public function resolve(array $data, array $params = []) {
-        global $layoutCacheNode;
-        if (!empty($data['$hydrate'])) {
-            $layoutCacheNodeKey = md5(json_encode($data));
-            if (!empty($this->layoutCacheNode[$layoutCacheNodeKey])) {
-                //return result from node cache over entire request
-                $result = $this->layoutCacheNode[$layoutCacheNodeKey];
-            } else {
-                $result = $this->validate($data);
-                $result = $this->resolveInternal($result, $params);
-                //cache unique node result for entire request
-                $this->layoutCacheNode[$layoutCacheNodeKey] = $result;
-                $layoutCacheNode[$layoutCacheNodeKey] = $this->layoutCacheNode[$layoutCacheNodeKey];
-            }
-        } else {
-            $result = $this->validate($data);
-            $result = $this->resolveInternal($result, $params);
-        }
+        $result = $this->validate($data);
+        $result = $this->resolveInternal($result, $params);
         return $result;
     }
-
-    /**
-     * Empty the cache of hydrated nodes (may be needed for tests)
-     */
-    final public function clearCache() {
-        global $layoutCacheNode;
-        $layoutCacheNode = $this->layoutCacheNode = [];
-    }
-
 
     /**
      * Override this method to do the actual resolution.

--- a/tests/DataHydratorNodeCacheTest.php
+++ b/tests/DataHydratorNodeCacheTest.php
@@ -43,15 +43,12 @@ class DataHydratorNodeCacheTest extends TestCase {
         $cache2 = $this->hydrator->getCache($layoutCacheNodeKey2);
         $cacheHit = $cache2->get();
         $this->assertSame('baz', $cacheHit);
-        $this->assertSame(2, $this->hydrator->resolveCount); // node was processed - incrementing counter
 
         $spec = ['$hydrate' => 'param', 'ref' => 'foo']; //third req same as first
         $this->hydrator->resolve($spec, ['foo' => 'bar']);
-        $this->assertSame(2, $this->hydrator->resolveCount); // node returned from cache - not incremented
 
         $spec = ['$hydrate' => 'param', 'ref' => 'bif']; //fourth req new diff
         $this->hydrator->resolve($spec, ['bif' => 'bun']);
-        $this->assertSame(3, $this->hydrator->resolveCount); // node was processed - incrementing counter
 
     }
 }

--- a/tests/DataHydratorNodeCacheTest.php
+++ b/tests/DataHydratorNodeCacheTest.php
@@ -43,15 +43,15 @@ class DataHydratorNodeCacheTest extends TestCase {
         $cache2 = $this->hydrator->getCache($layoutCacheNodeKey2);
         $cacheHit = $cache2->get();
         $this->assertSame('baz', $cacheHit);
-        $this->assertSame(2, $this->hydrator->nodeResolved); // node was processed - incrementing counter
+        $this->assertSame(2, $this->hydrator->resolveCount); // node was processed - incrementing counter
 
         $spec = ['$hydrate' => 'param', 'ref' => 'foo']; //third req same as first
         $this->hydrator->resolve($spec, ['foo' => 'bar']);
-        $this->assertSame(2, $this->hydrator->nodeResolved); // node returned from cache - not incremented
+        $this->assertSame(2, $this->hydrator->resolveCount); // node returned from cache - not incremented
 
         $spec = ['$hydrate' => 'param', 'ref' => 'bif']; //fourth req new diff
         $this->hydrator->resolve($spec, ['bif' => 'bun']);
-        $this->assertSame(3, $this->hydrator->nodeResolved); // node was processed - incrementing counter
+        $this->assertSame(3, $this->hydrator->resolveCount); // node was processed - incrementing counter
 
     }
 }

--- a/tests/DataHydratorNodeCacheTest.php
+++ b/tests/DataHydratorNodeCacheTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @author Gary Pomerant <gpomerant@higherlogic.com>
+ * @copyright 2009-2022 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Hydrate\Tests;
+
+use Garden\Hydrate\DataHydrator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the `DataHydrator` class.
+ */
+class DataHydratorNodeCacheTest extends TestCase {
+    private $hydrator;
+
+    /**
+     * Set up a hydrator fixture for each test.
+     */
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->hydrator = new DataHydrator();
+
+    }
+
+    /**
+     * Test that node cache is working and counter is valid.
+     */
+    public function testRootParam(): void {
+        $spec = ['$hydrate' => 'param', 'ref' => 'foo'];
+
+        $this->hydrator->resolve($spec, ['foo' => 'bar']); //resolved once on a single request
+        $midCount = $this->hydrator->getResolveCount();
+        $this->assertSame(1, $midCount, 'missed count first');
+
+        $this->hydrator->resolve($spec, ['foo' => 'bar']); //resolving same again now found in cache
+        $dupCount = $this->hydrator->getResolveCount();
+        $this->assertSame(1, $dupCount, 'duplicate processed; not pulled from cache');
+
+        $spec = ['$hydrate' => 'param', 'ref' => 'baz'];
+        $this->hydrator->resolve($spec, ['baz' => 'bar']); //resolved new on a separate request not in cache
+        $nondupCount = $this->hydrator->getResolveCount();
+        $this->assertSame(2, $nondupCount, 'not fresh resolve');
+
+        $this->hydrator->clearResolverCache(); // clear resolver cache and count
+        $finalCount = $this->hydrator->getResolveCount();
+        $this->assertSame(0, $finalCount, 'cache not cleared');
+    }
+
+    /**
+     * Test that node cache is working and counter is valid on nested elements.
+     */
+    public function testNestedResolvers(): void {
+        $spec = ['$hydrate' => 'param', 'ref' => ['$hydrate' => 'param', 'ref' => 'foo']];
+        $this->hydrator->resolve($spec, ['foo' => 'bar', 'bar' => 'baz']);
+        $nestedCount = $this->hydrator->getResolveCount();
+        $this->assertSame(2, $nestedCount, 'nested not counted'); // count resolve nested
+        $this->hydrator->clearResolverCache(); // clear resolver count
+        $finalCount = $this->hydrator->getResolveCount();
+        $this->assertSame(0, $finalCount, 'cache not cleared'); // count cache cleared
+    }
+
+    /**
+     * Test that node cache is working and valid on nested elements.
+     */
+    public function testNestedResolversDuplicates(): void {
+        $spec = ['$hydrate' => 'param', 'ref' => ['$hydrate' => 'param', 'ref' => 'foo']];
+        $this->hydrator->resolve($spec, ['foo' => 'bar', 'bar' => 'baz', 'baz' => 'bip']);
+        $nestedCount = $this->hydrator->getResolveCount();
+        $this->assertSame(2, $nestedCount, 'nested not counted'); // count resolve nested
+        $this->hydrator->clearResolverCache(); // clear resolver count
+        $finalCount = $this->hydrator->getResolveCount();
+        $this->assertSame(0, $finalCount, 'cache not cleared'); // count cache cleared
+    }
+}

--- a/tests/DataHydratorNodeCacheTest.php
+++ b/tests/DataHydratorNodeCacheTest.php
@@ -32,14 +32,14 @@ class DataHydratorNodeCacheTest extends TestCase {
     public function testRootParam(): void {
         $spec = ['$hydrate' => 'param', 'ref' => 'foo']; //first req
         $layoutCacheNodeKey = md5(json_encode($spec));
-        $this->hydrator->resolve($spec, ['foo' => 'bar']);
+        $this->hydrator->resolve($spec, ['foo' => 'bar'], false);
         $cache = $this->hydrator->getCache($layoutCacheNodeKey);
         $cacheHit = $cache->get();
         $this->assertSame('bar', $cacheHit);
 
         $spec = ['$hydrate' => 'param', 'ref' => 'bar']; //second req diff from first
         $layoutCacheNodeKey2 = md5(json_encode($spec));
-        $this->hydrator->resolve($spec, ['bar' => 'baz']);
+        $this->hydrator->resolve($spec, ['bar' => 'baz'], false);
         $cache2 = $this->hydrator->getCache($layoutCacheNodeKey2);
         $cacheHit = $cache2->get();
         $this->assertSame('baz', $cacheHit);

--- a/tests/DataHydratorNodeCacheTest.php
+++ b/tests/DataHydratorNodeCacheTest.php
@@ -33,24 +33,25 @@ class DataHydratorNodeCacheTest extends TestCase {
         $spec = ['$hydrate' => 'param', 'ref' => 'foo']; //first req
         $layoutCacheNodeKey = md5(json_encode($spec));
         $this->hydrator->resolve($spec, ['foo' => 'bar']);
-        $cache = $this->hydrator->getSimpleCache();
-        $cacheData = $cache->get($layoutCacheNodeKey);
-        $this->assertSame($cacheData, 'bar');
-        $this->assertTrue($cache->has($layoutCacheNodeKey));
+        $cache = $this->hydrator->getCache($layoutCacheNodeKey);
+        $cacheHit = $cache->get();
+        $this->assertSame('bar', $cacheHit);
 
-        $spec = ['$hydrate' => 'param', 'ref' => 'bar']; //second req
+        $spec = ['$hydrate' => 'param', 'ref' => 'bar']; //second req diff from first
         $layoutCacheNodeKey2 = md5(json_encode($spec));
         $this->hydrator->resolve($spec, ['bar' => 'baz']);
-        $cache = $this->hydrator->getSimpleCache();
-        $cacheData = $cache->get($layoutCacheNodeKey2);
-        $this->assertSame($cacheData, 'baz');
-        $this->assertTrue($cache->has($layoutCacheNodeKey2));
+        $cache2 = $this->hydrator->getCache($layoutCacheNodeKey2);
+        $cacheHit = $cache2->get();
+        $this->assertSame('baz', $cacheHit);
+        $this->assertSame(2, $this->hydrator->nodeResolved); // node was processed - incrementing counter
 
-
-        $spec = ['$hydrate' => 'param', 'ref' => 'foo']; //same as first now from cache
-        $layoutCacheNodeKey = md5(json_encode($spec));
+        $spec = ['$hydrate' => 'param', 'ref' => 'foo']; //third req same as first
         $this->hydrator->resolve($spec, ['foo' => 'bar']);
-        $cacheData = $cache->get($layoutCacheNodeKey);
-        $this->assertSame($cacheData, 'bar');
+        $this->assertSame(2, $this->hydrator->nodeResolved); // node returned from cache - not incremented
+
+        $spec = ['$hydrate' => 'param', 'ref' => 'bif']; //fourth req new diff
+        $this->hydrator->resolve($spec, ['bif' => 'bun']);
+        $this->assertSame(3, $this->hydrator->nodeResolved); // node was processed - incrementing counter
+
     }
 }


### PR DESCRIPTION
This PR relates to the [following issue](https://higherlogic.atlassian.net/browse/VNLA-676).

Cache each unique resolved node response in the new Layout Hydrator, and return a node from cache if it subsequently appear in same request.

This was added to the resolver() in the AbstractDataResolver class in the garden-hydrate repo as this is a final class (not being extended) and by using a **global** variable it can be persisted in memory and available for each/all nodes being resolved in the request.

QA: It will not be visible to users or through the front-end that this is happening. There will be tests add that will confirm it is working as intended.