### PR TITLE
Update to use garden-schema 3 and support php 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["7.4", "8.0", "8.1", "8.2"]
+        php-version: ["7.4", "8.0", "8.3"]
     steps:
       - uses: actions/checkout@v3
       - name: Installing PHP ${{ matrix.php-version }}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "vanilla/garden-jsont": "^1.2",
-        "vanilla/garden-schema": "^1.10.2",
+        "vanilla/garden-schema": "^3.0",
         "symfony/cache": "^4.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "vanilla/garden-jsont": "^1.2",
-        "vanilla/garden-schema": "^3.0",
-        "symfony/cache": "^4.4"
+        "vanilla/garden-jsont": ">=1.2",
+        "vanilla/garden-schema": ">=3.0",
+        "symfony/cache": ">=4.0"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    phpVersion="8.0"
 >
     <projectFiles>
         <directory name="src" />

--- a/tests/SprintfResolverTest.php
+++ b/tests/SprintfResolverTest.php
@@ -33,7 +33,7 @@ class SprintfResolverTest extends TestCase {
         $resolver = new SprintfResolver();
 
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('format is not');
+        $this->expectExceptionMessage('format: The value is not a valid string.');
         $actual = $resolver->resolve(['format' => []], []);
     }
 


### PR DESCRIPTION
See title.

I also dropped the intermediate PHP 8.x releases as we will be going straight from 8 -> 8.3.

The garden schema changes error messages a bit so I had to update 1 assertion.