### PR TITLE
Change a few function signatures

### DIFF
--- a/src/Schema/HydrateableSchema.php
+++ b/src/Schema/HydrateableSchema.php
@@ -168,9 +168,9 @@ class HydrateableSchema extends Schema {
     /**
      * Add a not of hydrate key.
      *
-     * @param array $schemaArray
+     * @param $schemaArray
      */
-    private function markNotHydrate(array &$schemaArray) {
+    private function markNotHydrate(&$schemaArray) {
         $schemaArray['not'] = [
             "required" => [DataHydrator::KEY_HYDRATE],
         ];

--- a/src/Schema/HydrateableSchema.php
+++ b/src/Schema/HydrateableSchema.php
@@ -94,12 +94,11 @@ class HydrateableSchema extends Schema {
     /**
      * Allow hydrate in a schema.
      *
-     * @param array $schemaArray
+     * @param $schemaArray
      * @param bool $isTopLevel Set to true to indicate that we are the top level definition of the schema and not a property.
      *
-     * @return array
      */
-    private function allowHydrateInSchema(array $schemaArray, bool $isTopLevel = false): array {
+    private function allowHydrateInSchema($schemaArray, bool $isTopLevel = false) {
         $notHydrateable = $isTopLevel || ($schemaArray[self::X_NO_HYDRATE] ?? false);
 
         // Do items first.
@@ -180,10 +179,10 @@ class HydrateableSchema extends Schema {
     /**
      * Take a schema array and union it with the the root hydrator.
      *
-     * @param array $schemaArray
+     * @param $schemaArray
      * @return array[]
      */
-    private function oneOfWithHydrate(array $schemaArray): array {
+    private function oneOfWithHydrate($schemaArray): array {
         // Clear the description, we're hoisting it.
         $hydrateGroup = $schemaArray[self::X_HYDRATE_GROUP] ?? JsonSchemaGenerator::ROOT_HYDRATE_GROUP;
         $description = $schemaArray['description'] ?? null;

--- a/tests/SprintfResolverTest.php
+++ b/tests/SprintfResolverTest.php
@@ -44,7 +44,7 @@ class SprintfResolverTest extends TestCase {
         $resolver = new SprintfResolver();
 
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('args');
+        $this->expectExceptionMessage('args: "foo" is not a valid array.');
         $actual = $resolver->resolve(['format' => 'foo', 'args' => 'foo'], []);
     }
 }


### PR DESCRIPTION
This PR removes inaccurate restrictive typing on a few functions.
Also, a minor tweak on a test's assertion.

Related to the following issue: https://higherlogic.atlassian.net/browse/VNLA-8917